### PR TITLE
spec rebuild: 30 capability(ies) rebuilt from archive history

### DIFF
--- a/openspec/specs/admin-announcements/spec.md
+++ b/openspec/specs/admin-announcements/spec.md
@@ -35,3 +35,24 @@ Templates rendering announcement content SHALL escape HTML by default. Any opt-i
 - **WHEN** an admin saves an announcement whose body contains `<script>alert(1)</script>`
 - **THEN** rendered pages SHALL display the literal text, not execute the script
 
+### Requirement: Admin announcement form accepts optional scheduled publish time
+
+The new-announcement form (`POST /portal/admin/announcements/new`) and edit-announcement form (`POST /portal/admin/announcements/:id/update`) SHALL each accept an optional `scheduled_publish_at` form field. The field SHALL be rendered as an HTML `datetime-local` input. Empty input means "no schedule." A non-empty input parses as a `DateTime<Utc>` (treating the form value as UTC for v1; per-timezone handling is a future change).
+
+The admin detail page SHALL display the scheduled time if set, alongside the existing status indicator.
+
+#### Scenario: Form submission with schedule
+
+- **WHEN** an admin submits the new-announcement form with `scheduled_publish_at = "2026-06-01T09:00"`
+- **THEN** the resulting `CreateAnnouncementInput` carries `scheduled_publish_at = Some(2026-06-01T09:00 UTC)`; the row is saved as Draft with that timestamp; `publish_now` is implicitly false
+
+#### Scenario: Form submission without schedule
+
+- **WHEN** the form omits the field or submits empty
+- **THEN** the resulting input carries `scheduled_publish_at = None`; behavior matches today (Draft if `publish_now` is false; Published if true)
+
+#### Scenario: Form combining publish_now and schedule
+
+- **WHEN** the form has both `publish_now = true` AND `scheduled_publish_at = <future>`
+- **THEN** `publish_now` wins (the row goes Published immediately); the schedule field is dropped. This is the simpler precedence; alternative would be to reject the combo, but the current shape favors "publish now, don't get clever."
+

--- a/openspec/specs/admin-events/spec.md
+++ b/openspec/specs/admin-events/spec.md
@@ -38,3 +38,28 @@ Events with a recurrence pattern SHALL be stored as a series with a generator th
 - **WHEN** an admin deletes a series
 - **THEN** future materialized instances SHALL be removed; past instances SHALL be retained for audit
 
+### Requirement: Tests of the recurring-event materializer use anchors relative to runtime
+
+Tests asserting on `RecurringEventService::create_series_with_initial_materialization` (or the materializer's output more generally) SHALL compute their input anchors and `until_date` values relative to `Utc::now()` at runtime. Fixed-calendar timestamps SHALL NOT be used as test inputs to the materializer.
+
+This rule applies BOTH to standalone test files under `tests/` AND to inline `#[cfg(test)] mod tests` blocks inside `src/` files (such as `src/service/event_admin_service.rs`). Wherever a test exercises the materializer, the inputs SHALL be runtime-relative.
+
+The reason: the materializer's horizon is `now + 12 months`. A fixed-calendar anchor drifts further into the past as wall-clock time advances, changing the gap between the anchor and the horizon. Tests that assert occurrence counts (with any tolerance) inevitably break as the gap widens. Tests that constrain via a fixed-calendar `until_date` work until "now" passes that date, at which point the materializer's effective horizon resolves to a past timestamp and produces an empty occurrence set.
+
+Relative-anchor helpers (e.g., `next_tuesday_anchor()` returning the next Tuesday after `Utc::now() + 1 day`) keep the test inputs in the same temporal position regardless of when the suite runs.
+
+#### Scenario: Test anchor is computed from runtime, not hardcoded
+
+- **WHEN** a contributor writes a test that calls `create_series_with_initial_materialization` and asserts an occurrence count or `materialized_through` value
+- **THEN** the anchor SHALL be computed from `Utc::now()` (e.g., via a helper that finds the next occurrence-eligible weekday at a chosen time) and any dependent `until_date` SHALL be computed as a relative offset from that anchor
+
+#### Scenario: Hardcoded calendar timestamps in materializer tests are a defect
+
+- **WHEN** a contributor inspects a recurring-event test file or any `src/` file with `#[cfg(test)] mod tests`
+- **THEN** instances of `Utc.with_ymd_and_hms(<year>, <month>, <day>, ...)` used as materializer inputs SHALL be treated as defects to be replaced with relative-anchor helpers; the rule is "no fixed-calendar inputs to the materializer in tests, regardless of where the test lives"
+
+#### Scenario: Inline test modules in src/ follow the same rule
+
+- **WHEN** an inline `#[cfg(test)] mod tests` block inside a service file (e.g., `src/service/event_admin_service.rs`) exercises the materializer or the service that wraps it
+- **THEN** the test SHALL use runtime-relative anchors. The helpers MAY be duplicated per-file rather than shared until a third caller appears; premature extraction to a shared `src/service/test_helpers.rs` is not required
+

--- a/openspec/specs/admin-members-handlers-layout/spec.md
+++ b/openspec/specs/admin-members-handlers-layout/spec.md
@@ -1,0 +1,36 @@
+# admin-members-handlers-layout Specification
+
+## Purpose
+TBD - created by archiving change a28-split-admin-members-handlers. Update Purpose after archive.
+## Requirements
+### Requirement: Admin member handlers are organized into focused submodules
+
+`src/web/portal/admin/members/mod.rs` SHALL be reduced to route registration and module declarations. The handler functions SHALL be moved into focused submodules under `src/web/portal/admin/members/`:
+
+- `mod.rs` — router + module declarations
+- `list.rs` — member browse/listing handlers
+- `detail.rs` — member detail view + update
+- `create.rs` — new-member form + submit
+- `status.rs` — activate, suspend, expire-now
+- `dues.rs` — extend-dues, set-dues, member-payments view
+- `payments.rs` — record-payment page/submit + their local helpers (`parse_dollars_to_cents`, `rerender_with_error`)
+- `discord.rs` — discord-id update + result fragment helper
+- `verification.rs` — resend-verification + result fragment helper
+
+Each handler's visibility SHALL be the narrowest that satisfies the router's needs (`pub(super)` preferred where it works; `pub` otherwise).
+
+#### Scenario: No submodule exceeds 300 lines
+
+- **WHEN** the post-split files in `src/web/portal/admin/members/` are line-counted
+- **THEN** every file SHALL be ≤300 lines
+
+#### Scenario: All routes still resolve to the same handlers
+
+- **WHEN** integration tests that hit admin-member routes are run
+- **THEN** they SHALL pass without modification; URL → handler resolution behavior is unchanged
+
+#### Scenario: Local helpers stay with their callers
+
+- **WHEN** `parse_dollars_to_cents` and `rerender_with_error` are located after the split
+- **THEN** they SHALL live in `payments.rs` (the only submodule that uses them) as private functions, NOT promoted to a shared `helpers.rs` or `mod.rs`
+

--- a/openspec/specs/admin-members/spec.md
+++ b/openspec/specs/admin-members/spec.md
@@ -68,3 +68,54 @@ When an admin activates a member (for instance, transitioning Pending → Active
 - **WHEN** an admin activates a previously-Pending member
 - **THEN** any session rows the member had SHALL be deleted; their next page load SHALL go through the login flow (and thereafter pass `require_auth_redirect`)
 
+### Requirement: Admin members page links to the CSV export
+
+The admin members page (`/portal/admin/members`) SHALL include a visible "Download CSV" link that points at `/portal/admin/members/export`. The link SHALL preserve the current filter query string (e.g., if the page is filtered to `?status=Active`, the link points at `/portal/admin/members/export?status=Active`).
+
+#### Scenario: Filter state is preserved in the export link
+
+- **WHEN** an admin visits `/portal/admin/members?status=Expired&type=annual`
+- **THEN** the page renders a "Download CSV" link with `href="/portal/admin/members/export?status=Expired&type=annual"`
+
+#### Scenario: Link is admin-only (lives on an admin-only page)
+
+- **WHEN** a non-admin somehow reaches the link
+- **THEN** the export endpoint itself rejects the request via `require_admin_redirect`
+
+### Requirement: Admin members page links to the bulk import flow
+
+The admin members page (`/portal/admin/members`) SHALL include a visible "Bulk import" button or link that navigates to `/portal/admin/members/import`. The import page renders a form with a file input and a brief format reminder listing the required and optional columns.
+
+#### Scenario: Bulk-import entry point is reachable from the members page
+
+- **WHEN** an admin visits `/portal/admin/members`
+- **THEN** the page SHALL render a "Bulk import" affordance alongside the existing "New Member" affordance
+
+#### Scenario: Format reminder lists required and optional columns
+
+- **WHEN** an admin visits `/portal/admin/members/import`
+- **THEN** the page SHALL display the required columns (`email`, `username`, `full_name`, `membership_type_slug`) and the optional ones (`status`, `notes`, `discord_id`) clearly enough that a first-time user knows what to put in their CSV
+
+### Requirement: Bulk-CSV admin handlers live in a sibling sub-module
+
+The bulk-CSV admin operations (`admin_members_export`, `admin_members_import_page`, `admin_members_import`, plus their supporting templates and parse/render helpers) SHALL live in `src/web/portal/admin/members/bulk.rs`, a sub-module of the `members` admin module. The per-member admin handlers (single-member CRUD, status transitions, dues operations) SHALL live in `src/web/portal/admin/members/mod.rs`.
+
+`members/mod.rs` SHALL re-export the public surface from `bulk` (typically via `pub use bulk::*;`) so route registration continues to resolve handler names at `admin::members::<name>` without needing to know the internal `bulk` sub-path.
+
+The intent: `members/mod.rs` is the per-member admin page; `bulk.rs` is the roster-level bulk operations. Each file has a coherent identity. The shared parent module groups them under one URL family.
+
+#### Scenario: New bulk-CSV handler lands in bulk.rs
+
+- **WHEN** a contributor adds a new bulk-CSV admin operation (e.g., bulk export of payment history)
+- **THEN** the handler, its template, and its helpers SHALL be added to `bulk.rs`, not to `mod.rs`
+
+#### Scenario: New per-member handler lands in mod.rs
+
+- **WHEN** a contributor adds a new per-member admin action (e.g., a "force-verify email" button)
+- **THEN** the handler SHALL be added to `mod.rs`, not to `bulk.rs`
+
+#### Scenario: Route registration stays flat
+
+- **WHEN** the router file (`src/web/portal/mod.rs`) registers a bulk-CSV route
+- **THEN** the handler path SHALL read `admin::members::admin_members_export` (or equivalent), NOT `admin::members::bulk::admin_members_export`; the `pub use bulk::*;` re-export flattens the path
+

--- a/openspec/specs/admin-payments/spec.md
+++ b/openspec/specs/admin-payments/spec.md
@@ -26,3 +26,19 @@ Manual payment recording SHALL go through the payment service so that audit-log 
 - **WHEN** an admin refunds a Stripe-backed payment
 - **THEN** the system SHALL call Stripe to issue the refund, record the resulting refund id, and emit an audit-log entry
 
+### Requirement: Refund handler lives in admin/payments.rs and routes through PaymentAdminService
+
+The `admin_refund_payment` handler SHALL live in `src/web/portal/admin/payments.rs`, not in `src/web/portal/admin/members.rs`. The file location matches the URL path (`/portal/admin/payments/:id/refund`).
+
+The handler SHALL parse the URL path parameter and the IP from headers, then call `PaymentAdminService::refund(current_user.id, payment_id, ip)`. The handler SHALL render `refund_result_html` based on the typed `Result<RefundOutcome, RefundError>` returned. Handler body SHALL be on the order of 25 lines; the orchestration chain is in the service, not here.
+
+#### Scenario: Refund handler file location matches URL
+
+- **WHEN** a contributor looks for the handler serving `POST /portal/admin/payments/:id/refund`
+- **THEN** they SHALL find it in `src/web/portal/admin/payments.rs`, not in `members.rs`
+
+#### Scenario: Handler is parse-call-render
+
+- **WHEN** the handler runs
+- **THEN** its body SHALL parse path/headers, call `PaymentAdminService::refund(...)`, and render based on the result; it SHALL NOT call `payment_repo`, `stripe_client`, `audit_service`, `integration_manager`, or `money_limiter` directly
+

--- a/openspec/specs/admin-types/spec.md
+++ b/openspec/specs/admin-types/spec.md
@@ -13,6 +13,22 @@ The system SHALL provide three configurable type lists managed through the porta
 
 Each list SHALL support new, edit, and delete via the admin pages. The handler SHALL emit audit-log entries via `audit_service.log` after a successful service-layer mutation; the type services themselves do NOT emit audits.
 
+Audit row shape for each mutation:
+
+| Operation | action string | entity_type | old_value | new_value |
+|-----------|--------------|-------------|-----------|-----------|
+| Create event type | `create_event_type` | `event_type` | None | type name |
+| Update event type | `update_event_type` | `event_type` | old name | new name |
+| Delete event type | `delete_event_type` | `event_type` | old name | None |
+| Create announcement type | `create_announcement_type` | `announcement_type` | None | type name |
+| Update announcement type | `update_announcement_type` | `announcement_type` | old name | new name |
+| Delete announcement type | `delete_announcement_type` | `announcement_type` | old name | None |
+| Create membership type | `create_membership_type` | `membership_type` | None | type name |
+| Update membership type | `update_membership_type` | `membership_type` | old name | new name |
+| Delete membership type | `delete_membership_type` | `membership_type` | old name | None |
+
+For updates and deletes, the handler SHALL fetch the existing type's name BEFORE calling the service so `old_value` captures the pre-mutation state (otherwise the post-delete read would return nothing).
+
 The event-type and announcement-type handler sets SHALL share a single implementation parameterized by `BasicTypeKind`. The membership-type handler set SHALL remain separate. URLs, form bodies, and rendered templates SHALL be unchanged from the pre-consolidation behavior.
 
 #### Scenario: Creating a new event type is admin-only
@@ -29,6 +45,26 @@ The event-type and announcement-type handler sets SHALL share a single implement
 
 - **WHEN** a contributor inspects the admin handlers for event types and announcement types
 - **THEN** they SHALL find a single set of handler functions (or one handler per CRUD operation) parameterized by `BasicTypeKind`; the only divergence SHALL be the URL prefix, the kind threaded through the handler, and the template path
+
+#### Scenario: Creating a type writes an audit row
+
+- **WHEN** an admin creates a new membership type named "Annual" via the admin form
+- **THEN** the `audit_logs` table SHALL gain one row with `actor_id = <admin's member id>`, `action = "create_membership_type"`, `entity_type = "membership_type"`, `entity_id = <new type's UUID>`, `old_value = NULL`, `new_value = "Annual"`
+
+#### Scenario: Updating a type writes an audit row with the old and new names
+
+- **WHEN** an admin renames an event type from "Workshop" to "Tournament"
+- **THEN** the `audit_logs` table SHALL gain one row with `action = "update_event_type"`, `entity_type = "event_type"`, `old_value = "Workshop"`, `new_value = "Tournament"`
+
+#### Scenario: Deleting a type writes an audit row with the old name
+
+- **WHEN** an admin deletes an announcement type named "Newsletter"
+- **THEN** the `audit_logs` table SHALL gain one row with `action = "delete_announcement_type"`, `entity_type = "announcement_type"`, `old_value = "Newsletter"`, `new_value = NULL`
+
+#### Scenario: Audit insert failure does not roll back the mutation
+
+- **WHEN** the audit-log insert errors (transient DB issue) after a successful type mutation
+- **THEN** the type mutation SHALL remain committed; the audit failure SHALL be logged via `tracing` but not propagated to the client (per the `audit-logging` capability's fire-and-forget contract)
 
 ### Requirement: Membership types govern dues amount and period
 

--- a/openspec/specs/audit-logging/spec.md
+++ b/openspec/specs/audit-logging/spec.md
@@ -23,39 +23,49 @@ Each `audit_logs` row SHALL include:
 
 - `id` (UUID v4)
 - `actor_id` (Option<UUID>) — the acting member, or NULL for system-initiated entries
-- `action` (string) — e.g., `activate_member`, `suspend_member`, `update_member`, `record_payment`, `refund_payment`, `update_setting`, `logout`, `migrate_stripe_subs`
+- `action` (string) — e.g., `activate_member`, `suspend_member`, `update_member`, `record_payment`, `refund_payment`, `update_setting`, `logout`, `migrate_stripe_subs`, `export_members`, `import_member`, `import_members_batch`
 - `entity_type` (string) — e.g., `member`, `payment`, `setting`, `session`
-- `entity_id` (string) — the UUID or other identifier of the target
-- `old_value` (Option<string>) — opaque before-state, often a name/email or JSON blob
-- `new_value` (Option<string>)
+- `entity_id` (string) — the UUID or other identifier of the target. For aggregate batch actions (`export_members`, `import_members_batch`), the value `"*"` SHALL be used.
+- `old_value` (Option<string>) — opaque before-state
+- `new_value` (Option<string>) — opaque after-state, OR for aggregate actions a brief filter+count summary
 - `ip_address` (Option<string>)
 - `created_at` (timestamp, set by DB default)
 
-#### Scenario: Activate-member entry carries member email as new_value
+#### Scenario: import_member row carries new-member email
 
-- **WHEN** an admin activates a member
-- **THEN** the inserted row SHALL have `action = "activate_member"`, `entity_type = "member"`, `entity_id = <member uuid>`, and `new_value` holding the member's email for human readability
+- **WHEN** a row is successfully imported via bulk import
+- **THEN** the inserted `audit_logs` row SHALL have `action = "import_member"`, `entity_type = "member"`, `entity_id = <new member uuid>`, and `new_value = Some(email)`
+
+#### Scenario: import_members_batch row summarizes the batch
+
+- **WHEN** a bulk import completes (regardless of partial failures)
+- **THEN** the inserted aggregate row SHALL have `action = "import_members_batch"`, `entity_type = "member"`, `entity_id = "*"`, and `new_value` of the form `"file=<name>,succeeded=N,failed=M"`
 
 ### Requirement: Locus of audit emission varies by domain
 
 Audit-log emission SHALL live EITHER in the service layer OR in the handler, depending on the domain:
 
-- **Payments**: emitted from `PaymentService` (e.g., `record_manual` calls `audit_service.log` internally). Adding a new payment-recording call site WITHOUT going through `PaymentService` would skip the audit.
-- **Member operations** (activate, suspend, update, extend-dues, set-dues, expire-now, create, update-discord-id, resend-verification): emitted from the **handler** in `src/web/portal/admin/members.rs` AFTER calling `member_repo` directly. There is no `MemberService` wrapping these calls.
-- **Settings, types, announcements, events**: emitted from the handler.
+- **Payments**: emitted from `PaymentService::record_manual` and from the per-event handlers inside `WebhookDispatcher`. Adding a new payment-recording call site WITHOUT going through one of these would skip the audit; the `payment-recording` capability spec lists the three permitted entry points.
+- **Member operations** (activate, suspend, update, extend-dues, set-dues, expire-now, create, update-discord-id, resend-verification, bulk-import): emitted from `MemberService` in `src/service/member_service.rs`. The handler in `src/web/portal/admin/members/` SHALL NOT emit audit logs directly for these operations; the service handles it.
+- **Settings, types, announcements, events**: emitted from the handler. (The `admin-types` capability's audit emission is a real bug today — the spec says the handler audits, but the code doesn't. A separate change adds the missing calls.)
 - **Logout**: emitted from the handler in `src/api/handlers/auth.rs`.
 
-This is observed behavior. The CLAUDE.md "side-effects live in services" rule is aspirational; payments follow it, the rest do not.
+This reflects current code structure: member operations and payments follow the CLAUDE.md "side-effects in services" rule; type/setting/announcement/event ops have audit in handlers.
 
-#### Scenario: New member-mutation handler must emit its own audit row
+#### Scenario: New member-mutation method must emit its own audit row from the service
 
-- **WHEN** a contributor adds a new member-mutation route to `src/web/portal/admin/members.rs`
-- **THEN** the handler MUST explicitly call `state.service_context.audit_service.log(...)` because no member-service wrapper does so on its behalf
+- **WHEN** a contributor adds a new member-mutation method to `MemberService`
+- **THEN** the method MUST explicitly call `self.audit_service.log(...)` after the repo update; no handler-side audit wrapper exists for member operations
 
-#### Scenario: New payment recording site routes through PaymentService
+#### Scenario: New payment recording site routes through one of the three entry points
 
 - **WHEN** a contributor adds a new code path that records a payment
-- **THEN** it SHALL call `PaymentService::record_manual` (or the equivalent service entry point), which emits the audit row internally
+- **THEN** it SHALL call one of `PaymentService::record_manual`, `WebhookDispatcher::handle_*`, or `BillingService::process_scheduled_payment` — each emits the audit row internally; direct `payment_repo.create` calls are forbidden
+
+#### Scenario: Handler does not emit duplicate audit for member operations
+
+- **WHEN** an admin-member handler is reviewed
+- **THEN** it SHALL NOT contain a direct `audit_service.log` call for member-mutation actions; the service emits the row
 
 ### Requirement: Audit log is append-only at the application layer
 

--- a/openspec/specs/auth-middleware-tiers/spec.md
+++ b/openspec/specs/auth-middleware-tiers/spec.md
@@ -105,3 +105,42 @@ A non-admin authenticated member SHALL be redirected to `/portal/dashboard`. An 
 - **WHEN** an authenticated Pending-status member hits an `/api/*` member route
 - **THEN** the response SHALL be 403 Forbidden
 
+### Requirement: Gating middlewares share a single core implementation
+
+The four gating middlewares (`require_auth`, `require_auth_redirect`, `require_restorable`, `require_admin_redirect`) and `optional_auth` SHALL share a single `authenticate(...)` core that performs the cookie-read, session-validate, member-load, and status-check sequence exactly once. Per-variant differences (allowed status set, on-reject behavior, admin-flag check, TOTP enforcement) SHALL be expressed as data — typically an `AccessPolicy` value — passed into the shared core, not as duplicated imperative code in each middleware body.
+
+A future change to session validation, member loading, or `CurrentUser`/`SessionInfo` injection SHALL only need to land in the shared core; per-variant wrapper code SHALL NOT need to be touched.
+
+#### Scenario: New variant uses the shared core
+
+- **WHEN** a contributor adds a new auth middleware variant (e.g., a hypothetical `require_member_or_admin`)
+- **THEN** the variant SHALL be expressed as a small wrapper that builds an `AccessPolicy` and delegates to the shared `authenticate(...)`; it SHALL NOT re-implement cookie/session/member-loading logic
+
+#### Scenario: Session validation fix lands in one place
+
+- **WHEN** a contributor changes how `auth_service.validate_session(...)` is called (e.g., adds session-id rotation)
+- **THEN** the change SHALL land inside the shared core function and SHALL automatically apply to every wrapper without per-wrapper edits
+
+### Requirement: Middlewares use the shared MemberRepository from ServiceContext
+
+Auth middleware SHALL load members via `state.service_context.member_repo` (the shared `Arc<dyn MemberRepository>`). Constructing a fresh `SqliteMemberRepository::new(...)` inside the middleware body SHALL NOT be done.
+
+#### Scenario: Member-load uses the shared repo Arc
+
+- **WHEN** any auth middleware loads the current member
+- **THEN** it SHALL call `state.service_context.member_repo.find_by_id(...)`; it SHALL NOT call `SqliteMemberRepository::new(state.service_context.db_pool.clone())`
+
+#### Scenario: Tests can inject a fake member repo
+
+- **WHEN** a test wires a fake `MemberRepository` into `ServiceContext`
+- **THEN** the auth middleware SHALL exercise the fake (it cannot bypass it by constructing its own SQLite repo)
+
+### Requirement: Public middleware names and signatures are stable
+
+`require_auth`, `require_auth_redirect`, `require_restorable`, `require_admin_redirect`, and `optional_auth` SHALL remain the public symbols routers reference. Their signatures SHALL match the existing `(State<AppState>, CookieJar, Request, Next) -> Response` (or `Result<Response, AppError>` for `require_auth`) shape so no router file is forced to change as a consequence of the internal consolidation.
+
+#### Scenario: Routers do not move when the internals consolidate
+
+- **WHEN** the auth-middleware refactor ships
+- **THEN** `src/api/mod.rs`, `src/web/portal/mod.rs`, and `src/web/mod.rs` SHALL NOT need import or signature changes; the same `route_layer(from_fn_with_state(state, require_*))` lines continue to compile
+

--- a/openspec/specs/bootstrap-admin-cli/spec.md
+++ b/openspec/specs/bootstrap-admin-cli/spec.md
@@ -1,0 +1,55 @@
+# bootstrap-admin-cli Specification
+
+## Purpose
+TBD - created by archiving change a23-create-admin-cli. Update Purpose after archive.
+## Requirements
+### Requirement: A `create_admin` binary creates the first admin without HTTP
+
+The system SHALL ship a `create_admin` binary at `target/release/create_admin` (and in the release tarball alongside `coterie` and `seed`). It SHALL accept the following arguments:
+
+- `--email <EMAIL>` (required)
+- `--username <USERNAME>` (required)
+- `--full-name <NAME>` (required)
+- `--password <PASSWORD>` OR `--password-file <PATH>` (exactly one required)
+
+The binary SHALL:
+
+1. Load configuration via `Settings::new()` (same as the coterie server binary).
+2. Connect to the SQLite database via `SqliteConnectOptions::create_if_missing(true)` (matching the server's connect logic).
+3. Run pending migrations via `sqlx::migrate!()`.
+4. Refuse with exit code 2 and a clear stderr message if any admin already exists.
+5. Hash the password using the same argon2 parameters as `AuthService` uses for /setup form submissions.
+6. Insert a single member row with `status = Active`, `is_admin = true`, `email_verified_at = NOW()`, and the hashed password.
+7. Exit 0 on success.
+
+#### Scenario: Happy path on a fresh database
+
+- **WHEN** `create_admin --email founder@org --username founder --full-name 'Founder Name' --password-file /tmp/pw` runs against a fresh, migrated DB
+- **THEN** exit code SHALL be 0; a single `members` row SHALL exist with the supplied email, username, full_name, `is_admin = 1`, `status = "Active"`, and `email_verified_at` set to a recent timestamp; the password hash SHALL be verifiable via the existing `AuthService::verify_password` logic
+
+#### Scenario: Refuse when admin already exists
+
+- **WHEN** `create_admin` is invoked against a DB that already contains a row with `is_admin = 1`
+- **THEN** exit code SHALL be 2; stderr SHALL contain a message like "Admin already exists; refusing to create another via CLI"; the database SHALL be unchanged
+
+#### Scenario: Refuse when both password forms are supplied
+
+- **WHEN** `create_admin` is invoked with both `--password` and `--password-file`
+- **THEN** exit code SHALL be non-zero (clap's standard usage error, code 2); stderr SHALL identify the mutual exclusion
+
+#### Scenario: Migrations run automatically
+
+- **WHEN** `create_admin` is invoked against a DB file that doesn't exist yet
+- **THEN** the SQLite file is created, migrations are applied to bring the schema to current, and then the admin insert proceeds (single command brings a totally fresh DB to "ready with one admin")
+
+### Requirement: Password is read safely from a file
+
+When `--password-file` is supplied, the binary SHALL read the entire file contents, strip trailing whitespace (including a trailing newline if present), and use the result as the password. The file SHALL NOT be deleted or modified by the binary — its lifecycle is the caller's responsibility.
+
+The `--password <STRING>` form is supported for testing and ad-hoc use, but the recommended path for automation (the provisioning wizard, scripted re-deploys) is `--password-file` to avoid the password appearing in process listings.
+
+#### Scenario: Password file with trailing newline
+
+- **WHEN** the password file contains `"secret123\n"` (with a trailing newline as would happen from `echo` or a heredoc)
+- **THEN** the resulting password hash SHALL match `"secret123"` (no trailing newline); verification with `"secret123"` SHALL succeed
+

--- a/openspec/specs/bulk-member-csv-export/spec.md
+++ b/openspec/specs/bulk-member-csv-export/spec.md
@@ -1,0 +1,53 @@
+# bulk-member-csv-export Specification
+
+## Purpose
+TBD - created by archiving change a12-bulk-member-csv-export. Update Purpose after archive.
+## Requirements
+### Requirement: Admins can download the member roster as CSV
+
+The system SHALL expose `GET /portal/admin/members/export` returning the member roster as `text/csv; charset=utf-8`. The response SHALL include `Content-Disposition: attachment; filename="members-export-YYYY-MM-DD.csv"` so browsers download rather than render. The endpoint SHALL be gated by `require_admin_redirect`.
+
+The CSV SHALL contain a header row followed by one row per member matching the current filter. The columns SHALL be, in this order:
+
+`id, email, username, full_name, status, membership_type, joined_at, dues_paid_until, is_admin, bypass_dues, discord_id, email_verified_at, notes`
+
+The CSV SHALL NOT include any credential field: no password hash, no TOTP secret, no recovery codes, no Stripe customer/subscription IDs.
+
+#### Scenario: Admin gets a downloadable file
+
+- **WHEN** an admin requests `GET /portal/admin/members/export`
+- **THEN** the response SHALL have status 200, `Content-Type: text/csv; charset=utf-8`, and `Content-Disposition: attachment; filename="members-export-YYYY-MM-DD.csv"` with the date of the request
+
+#### Scenario: Non-admin cannot reach the export
+
+- **WHEN** an authenticated non-admin requests `GET /portal/admin/members/export`
+- **THEN** the request SHALL be redirected to `/portal/dashboard` by `require_admin_redirect` (same as every other admin route)
+
+#### Scenario: CSV escapes special characters
+
+- **WHEN** a member's `full_name` is `"O'Brien, Sean"` or `notes` contain a comma, quote, or newline
+- **THEN** the CSV writer SHALL escape these per RFC 4180 (double-quote the field; double up any internal double-quotes)
+
+### Requirement: Export respects the same filters as the admin page
+
+The export endpoint SHALL accept the same query string parameters as `/portal/admin/members` (`q` for search, `status` for status filter, `type` for membership type slug). The export SHALL include exactly the members that the filtered view would show, with pagination removed (`limit = unbounded`).
+
+#### Scenario: Status filter narrows the export
+
+- **WHEN** an admin requests `/portal/admin/members/export?status=Active`
+- **THEN** the CSV SHALL contain only members whose status is Active
+
+#### Scenario: No filter exports everything
+
+- **WHEN** an admin requests `/portal/admin/members/export` with no query string
+- **THEN** the CSV SHALL contain every member of every status (Active, Pending, Expired, Suspended, Honorary)
+
+### Requirement: Exports are audit-logged
+
+Every successful export SHALL write an `audit_logs` row with `action = "export_members"`, `entity_type = "member"`, `entity_id = "*"`, `actor_id = <admin's member id>`, and `new_value` summarizing the filter and the row count (e.g., `"status=Active,count=42"`).
+
+#### Scenario: Successful export writes an audit row
+
+- **WHEN** an admin successfully exports the roster
+- **THEN** an `audit_logs` row SHALL be inserted with the fields above
+

--- a/openspec/specs/bulk-member-csv-import/spec.md
+++ b/openspec/specs/bulk-member-csv-import/spec.md
@@ -1,0 +1,61 @@
+# bulk-member-csv-import Specification
+
+## Purpose
+TBD - created by archiving change a13-bulk-member-csv-import. Update Purpose after archive.
+## Requirements
+### Requirement: Admins can bulk-create members from a CSV upload
+
+The system SHALL expose `POST /portal/admin/members/import` accepting `multipart/form-data` with a CSV file in a `file` field. The endpoint SHALL be gated by `require_admin_redirect`. Maximum file size SHALL be 5 MB.
+
+The CSV's header row MUST include the columns `email`, `username`, `full_name`, `membership_type_slug`. Optional columns: `status` (default `Pending`), `notes`, `discord_id`. Other columns SHALL be silently ignored.
+
+Each data row SHALL be processed independently. A failing row SHALL NOT prevent subsequent rows from succeeding.
+
+#### Scenario: Successful import of N members
+
+- **WHEN** an admin uploads a CSV with 10 valid rows
+- **THEN** 10 new `members` rows SHALL be created with `status = Pending` (or the row's specified status); each gets its own `audit_logs` row with `action = "import_member"`
+
+#### Scenario: Partial-failure import
+
+- **WHEN** an admin uploads a CSV where 7 rows are valid and 3 have duplicate emails
+- **THEN** 7 members SHALL be created; the response SHALL list the 3 failures with row index, the offending email, and a reason (e.g., "Email already exists")
+
+#### Scenario: Missing required column aborts the batch
+
+- **WHEN** the uploaded CSV lacks the `email` column in its header
+- **THEN** the handler SHALL return an error response identifying the missing column; no rows SHALL be created
+
+#### Scenario: Unknown membership_type_slug fails the row, not the batch
+
+- **WHEN** a row's `membership_type_slug` doesn't match any active row in `membership_types`
+- **THEN** that row SHALL be reported as a failure with the slug in the reason; other rows continue
+
+#### Scenario: Imported members have no password
+
+- **WHEN** a row creates a new member
+- **THEN** the resulting `members.password_hash` SHALL be a sentinel (matching the existing "no password yet" pattern in `MemberRepository::create`, if one exists; otherwise the row is unusable for login until the member sets a password via password-reset)
+
+### Requirement: Import does not overwrite existing members
+
+The import path SHALL be INSERT-only. A row whose `email` OR `username` matches an existing member SHALL be reported as a failure; the existing member SHALL NOT be modified.
+
+#### Scenario: Duplicate email is a failure, not an update
+
+- **WHEN** a row's email matches an existing member's email
+- **THEN** the row SHALL be reported as failed; the existing member's data SHALL be unchanged
+
+### Requirement: Import emits per-row and aggregate audit rows
+
+The import SHALL emit one `audit_logs` row per successfully created member (`action = "import_member"`) AND one aggregate row at the end of the batch (`action = "import_members_batch"`). Both carry the importing admin's `actor_id`.
+
+#### Scenario: Per-row audit row identifies the new member
+
+- **WHEN** a row is successfully imported
+- **THEN** an `audit_logs` row SHALL be inserted with `action = "import_member"`, `entity_id = <new member uuid>`, and `new_value = Some(email)`
+
+#### Scenario: Aggregate audit row summarizes the batch
+
+- **WHEN** a bulk import completes
+- **THEN** an `audit_logs` row SHALL be inserted with `action = "import_members_batch"`, `entity_id = "*"`, and `new_value` summarizing the counts (e.g., `"file=members.csv,succeeded=42,failed=3"`)
+

--- a/openspec/specs/domain-types/spec.md
+++ b/openspec/specs/domain-types/spec.md
@@ -137,3 +137,52 @@ The kind SHALL NOT be extended to admit user-controlled values. Adding a new var
 - **WHEN** a contributor adds a new `BasicTypeKind` variant
 - **THEN** the compiler SHALL fail to build until every const accessor (`table`, `usage_table`, `usage_fk`, `display_name`) returns a value for the new variant
 
+### Requirement: MemberStatus exposes typed predicate helpers
+
+`domain::MemberStatus` SHALL expose `pub fn is_active(self) -> bool`, `is_pending`, `is_expired`, `is_suspended`, and `is_honorary` predicate methods. These methods exist so callers — especially Askama templates rendering `MemberStatus` values from `MemberInfo` / `AdminMemberInfo` projections — can branch on status without comparing against string literals. A typo in a predicate name SHALL be caught at compile time; a renamed `MemberStatus` variant SHALL force every predicate to be updated.
+
+`MemberStatus` SHALL also derive `Copy` so the predicates can be called on owned values without `&` ceremony at the template call site.
+
+#### Scenario: Templates branch on typed predicates
+
+- **WHEN** a template renders a member context and needs to branch on the member's status
+- **THEN** it SHALL call `member.status.is_active()` (or the relevant predicate) rather than comparing against a string literal like `member.status == "Active"`
+
+#### Scenario: Renaming a variant catches drift at compile time
+
+- **WHEN** a contributor renames `MemberStatus::Pending` (e.g., to `Submitted`)
+- **THEN** the corresponding `is_pending` predicate SHALL be updated as part of the rename or the build SHALL fail; templates calling `is_pending` SHALL fail to render against the new variant set, surfacing the drift immediately rather than silently routing the wrong branch
+
+#### Scenario: Predicates are total over the variant set
+
+- **WHEN** a contributor adds a new variant to `MemberStatus`
+- **THEN** they SHALL also add the corresponding `is_<variant>` predicate so every variant is observable from templates without falling back to string comparison
+
+### Requirement: Member-context template projections carry typed status and dates
+
+The presentation projections `MemberInfo` (in `src/web/portal/mod.rs`) and `AdminMemberInfo` (in `src/web/portal/admin/members.rs`) SHALL hold:
+
+- `id: Uuid` (not `String`)
+- `status: MemberStatus` (not `String`)
+- `joined_at: DateTime<Utc>` (not pre-formatted `String`)
+- `dues_paid_until: Option<DateTime<Utc>>` (not `Option<String>`)
+
+Date formatting SHALL be applied at the template layer via Askama filters (`fmt_long_date`, `fmt_short_date`, plus `_opt` variants for `Option<DateTime<Utc>>`). Per-handler `format!("%B %d, %Y")` calls in projection construction sites SHALL be removed.
+
+The projections SHALL remain distinct types from `domain::Member` so that `Member` fields not safe to render to member-facing pages (`notes`, `stripe_customer_id`, `stripe_subscription_id`, `discord_id`) cannot leak into a template via the projection.
+
+#### Scenario: Construction sites pass typed values directly
+
+- **WHEN** a handler constructs `MemberInfo` from a `Member`
+- **THEN** the construction SHALL move `member.status`, `member.joined_at`, `member.dues_paid_until`, and `member.id` straight onto the projection without per-field `format!` or `.as_str()` conversion
+
+#### Scenario: Templates format dates via the filter, not via pre-formatted strings
+
+- **WHEN** a template renders `member.joined_at`
+- **THEN** it SHALL apply the appropriate filter (`{{ member.joined_at|fmt_long_date }}` or `|fmt_short_date`); the projection SHALL NOT carry a pre-formatted string
+
+#### Scenario: Adding a new render-shielded field to Member does not leak
+
+- **WHEN** a contributor adds a new field to `domain::Member` (e.g., a private admin note)
+- **THEN** the field SHALL NOT automatically appear on `MemberInfo` / `AdminMemberInfo`; the contributor must explicitly add it to a projection if it should render
+

--- a/openspec/specs/email-tokens/spec.md
+++ b/openspec/specs/email-tokens/spec.md
@@ -5,44 +5,67 @@ TBD - created by archiving change document-existing-architecture. Update Purpose
 ## Requirements
 ### Requirement: Tokens are stored as SHA-256 hashes
 
-`EmailTokenService` SHALL hash tokens with SHA-256 before persistence. The plaintext token SHALL exist only in the emailed URL and briefly in memory during request handling.
+`EmailTokenService` SHALL hash tokens with SHA-256 before persistence. The
+plaintext token SHALL exist only in the emailed URL and briefly in memory
+during request handling.
 
-#### Scenario: Database row contains hash only
+#### Scenario: Stored hash equals SHA-256(plaintext)
 
-- **WHEN** a row is inserted into `email_verification_tokens` or `password_reset_tokens`
-- **THEN** the `token_hash` column SHALL be `SHA-256(plaintext)`; the plaintext SHALL NOT be persisted
+- **WHEN** a token is created and the row inspected directly
+- **THEN** `token_hash` SHALL equal `hex::encode(Sha256::digest(plaintext))`
+  with no other transformation
 
 ### Requirement: Tokens are single-use via atomic consume
 
-`consume(token)` SHALL atomically flip `consumed_at` from NULL to the current time using a single UPDATE … RETURNING statement with `WHERE token_hash = ? AND consumed_at IS NULL AND expires_at > ?`. A second redemption attempt SHALL find no row matching all three conditions.
+`consume(token)` SHALL atomically flip `consumed_at` from NULL to the current
+time using a single UPDATE … RETURNING statement with `WHERE token_hash = ?
+AND consumed_at IS NULL AND expires_at > ?`. A second redemption attempt
+SHALL find no row matching all three conditions.
 
 #### Scenario: Token redeems exactly once
 
 - **WHEN** a token is consumed successfully
-- **THEN** subsequent `consume` calls with the same token SHALL return `None` because `consumed_at` is now non-NULL
+- **THEN** subsequent `consume` calls with the same token SHALL return
+  `None` because `consumed_at` is now non-NULL
 
-#### Scenario: Concurrent consume of the same token
+#### Scenario: Consume of an unknown plaintext returns None without error
 
-- **WHEN** two concurrent requests attempt to consume the same valid token
-- **THEN** the atomic UPDATE … RETURNING SHALL ensure exactly ONE caller receives the `ConsumedToken`; the other SHALL receive `None`
+- **WHEN** `consume("not-a-real-token")` is called
+- **THEN** it SHALL return `Ok(None)` (no row matched the SHA-256 hash)
 
 ### Requirement: Expired tokens cannot redeem
 
-The `WHERE` clause SHALL include `expires_at > now()` so an expired but unconsumed token SHALL NOT redeem.
+The `WHERE` clause SHALL include `expires_at > now()` so an expired but
+unconsumed token SHALL NOT redeem.
 
 #### Scenario: Expired token cannot redeem
 
 - **WHEN** a token is presented after its `expires_at`
-- **THEN** `consume` SHALL return `None` and any associated state change SHALL NOT occur
+- **THEN** `consume` SHALL return `None` AND the row's `consumed_at` SHALL
+  remain NULL (the gated UPDATE did nothing)
 
 ### Requirement: Cross-purpose protection is enforced by separate tables
 
-The service SHALL be constructed for a specific purpose via `EmailTokenService::verification(pool)` or `EmailTokenService::password_reset(pool)`. Each constructor binds the service to its own table (`email_verification_tokens` or `password_reset_tokens`). A token from one table SHALL NOT be redeemable through the other table's service instance.
+The service SHALL be constructed for a specific purpose via
+`EmailTokenService::verification(pool)` or
+`EmailTokenService::password_reset(pool)`. Each constructor binds the service
+to its own table (`email_verification_tokens` or `password_reset_tokens`). A
+token from one table SHALL NOT be redeemable through the other table's
+service instance.
 
 #### Scenario: Reset token cannot redeem at verification endpoint
 
-- **WHEN** a token issued by `password_reset` is presented to the `verification` service's `consume`
-- **THEN** the lookup SHALL find no row in `email_verification_tokens` and `consume` SHALL return `None`
+- **WHEN** a token issued by `password_reset` is presented to the
+  `verification` service's `consume`
+- **THEN** the lookup SHALL find no row in `email_verification_tokens` and
+  `consume` SHALL return `None`
+
+#### Scenario: Verification token cannot redeem at password-reset endpoint
+
+- **WHEN** a token issued by `verification` is presented to the
+  `password_reset` service's `consume`
+- **THEN** the lookup SHALL find no row in `password_reset_tokens` and
+  `consume` SHALL return `None`
 
 ### Requirement: Tokens are 256 bits of cryptographic randomness
 
@@ -55,19 +78,27 @@ Plaintext tokens SHALL be generated from 32 random bytes (256 bits) via the OS-R
 
 ### Requirement: Successful consume invalidates other outstanding tokens
 
-`invalidate_for_member(member_id)` SHALL set `consumed_at` to the current time on every outstanding (unconsumed) token for that member. Reset/verification flows SHALL invoke this after a successful consume so other in-flight tokens for the same member become unusable.
+`invalidate_for_member(member_id)` SHALL set `consumed_at` to the current
+time on every outstanding (unconsumed) token for that member.
+Reset/verification flows SHALL invoke this after a successful consume so
+other in-flight tokens for the same member become unusable.
 
-#### Scenario: Other outstanding reset tokens are killed after a successful reset
+#### Scenario: Other outstanding reset tokens are killed after invalidate
 
-- **WHEN** a member completes a password reset and the handler calls `invalidate_for_member`
-- **THEN** any other outstanding reset tokens (e.g., a forgotten earlier request) SHALL be marked consumed and unusable
+- **WHEN** a member has two outstanding reset tokens and the handler calls
+  `invalidate_for_member`
+- **THEN** both subsequent `consume` calls for those tokens SHALL return
+  `None`
 
 ### Requirement: Background cleanup prunes expired rows
 
-`cleanup_expired()` SHALL delete expired rows. Cleanup is best-effort; expiry is enforced at consume time regardless.
+`cleanup_expired()` SHALL delete expired rows. Cleanup is best-effort;
+expiry is enforced at consume time regardless.
 
-#### Scenario: Cleanup is not load-bearing for security
+#### Scenario: Cleanup removes only expired rows
 
-- **WHEN** `cleanup_expired` has not run for some time
-- **THEN** expired tokens SHALL still be unusable because `consume` enforces the expiry condition independently
+- **WHEN** the table holds one expired and one unexpired row, and
+  `cleanup_expired()` is called
+- **THEN** the call SHALL return 1 (rows deleted) AND the unexpired token
+  SHALL still successfully redeem via `consume`
 

--- a/openspec/specs/event-reminders/spec.md
+++ b/openspec/specs/event-reminders/spec.md
@@ -1,0 +1,61 @@
+# event-reminders Specification
+
+## Purpose
+TBD - created by archiving change a10-event-reminder-emails. Update Purpose after archive.
+## Requirements
+### Requirement: RSVP'd members receive one reminder email before an event
+
+For every event whose start time falls within `[now, now + lead_hours]`, the system SHALL email each member who has an active RSVP a reminder, EXACTLY ONCE per RSVP. The lead-hours window is configurable via the `events.reminder_lead_hours` setting (default 24).
+
+The reminder SHALL include the event title, formatted start time, location (if present on the event), and a link to the event's portal detail page.
+
+#### Scenario: RSVP'd member receives a reminder
+
+- **WHEN** a member has an active RSVP for an event starting in 23 hours AND the lead-hours setting is 24
+- **THEN** the next runner tick SHALL email that member; the attendee row SHALL be stamped with `reminder_sent_at = now`
+
+#### Scenario: Already-stamped row is skipped
+
+- **WHEN** the runner ticks again after a reminder was sent
+- **THEN** the same RSVP SHALL NOT generate a second email; the row's `reminder_sent_at` is non-null
+
+#### Scenario: Event outside the lead window is skipped
+
+- **WHEN** an event starts in 48 hours AND the lead-hours setting is 24
+- **THEN** no reminder SHALL be sent on this tick; the next tick will re-evaluate as the window approaches
+
+#### Scenario: Past events are not reminded
+
+- **WHEN** an event's start time is in the past
+- **THEN** no reminder SHALL be sent regardless of `reminder_sent_at` status
+
+#### Scenario: Late RSVP inside the window still gets a reminder
+
+- **WHEN** a member RSVPs to an event 6 hours before its start AND the lead-hours setting is 24
+- **THEN** the next runner tick SHALL include this RSVP and send the reminder (the window is `[now, now + lead_hours]`, generous on the recent-RSVP side)
+
+### Requirement: Reminder claim and send is atomic per RSVP
+
+The runner SHALL claim each RSVP for reminding via an atomic conditional UPDATE (`SET reminder_sent_at = now WHERE reminder_sent_at IS NULL`) that returns whether the row was claimed. The email SHALL be sent only after a successful claim, so two concurrent runner ticks cannot both email the same RSVP.
+
+If the post-claim email send fails, the row stays stamped — the RSVP will not be re-reminded. This is a documented trade-off (preferring "rare missed reminder" over "occasional duplicate reminder"). Operators can manually clear `reminder_sent_at` to retry.
+
+#### Scenario: Claim before send prevents duplicate emails
+
+- **WHEN** the runner identifies an eligible RSVP
+- **THEN** it SHALL conditionally stamp `reminder_sent_at` first; only on a successful row-count-1 update SHALL it send the email
+
+#### Scenario: Send failure does not unblock a re-attempt
+
+- **WHEN** the email send fails after a successful claim
+- **THEN** the row stays stamped; the failure is logged via `tracing`; operator intervention (clearing the column) is required to retry
+
+### Requirement: Lead-hours setting is read on each tick
+
+`Notifications::send_event_reminders` SHALL read the `events.reminder_lead_hours` setting at the start of each invocation. A missing or unparseable setting SHALL default to 24. This means operators can adjust the lead time without restarting the server.
+
+#### Scenario: Setting change takes effect on the next tick
+
+- **WHEN** an admin updates `events.reminder_lead_hours` from 24 to 48
+- **THEN** the next runner tick SHALL use 48 as the lead window
+

--- a/openspec/specs/integration-events/spec.md
+++ b/openspec/specs/integration-events/spec.md
@@ -40,24 +40,6 @@ Adding a new variant SHALL force every consumer match to be updated, preventing 
 - **WHEN** an integration's `is_enabled()` returns `false` at registration time
 - **THEN** it SHALL NOT be added to the manager's list; subsequent events SHALL skip it
 
-### Requirement: Events are dispatched from handlers (not services) for member operations
-
-For member-mutation operations (`activate`, `suspend`, `update`, etc.), the **handler** in `src/web/portal/admin/members.rs` SHALL call `state.service_context.integration_manager.handle_event(...)` after the repo update. There is no `MemberService` wrapping these calls.
-
-For payment operations, integration events (where applicable) SHALL be dispatched from `PaymentService`. (As of this change, payments do not produce `IntegrationEvent` variants directly; admin alerts on billing failures are dispatched by `BillingService`.)
-
-This is observed behavior. The CLAUDE.md "side-effects in services" rule is aspirational; payments follow it, member operations do not.
-
-#### Scenario: New member-mutation handler must dispatch events explicitly
-
-- **WHEN** a contributor adds a new member-mutation route
-- **THEN** the handler MUST explicitly call `integration_manager.handle_event(...)` after the repo update; no service-layer wrapper does so on its behalf
-
-#### Scenario: BillingService dispatches AdminAlert on dunning
-
-- **WHEN** the billing runner records the configured threshold of consecutive failures for a member
-- **THEN** `BillingService` (not the handler) SHALL dispatch `IntegrationEvent::AdminAlert` so the admin-alert email integration sends a notification
-
 ### Requirement: Event consumers do not block the originating call
 
 `handle_event` is `async` but called from handlers WITHOUT spawning. Consumers SHALL be implemented to be reasonably fast (millisecond-scale typical) so they do not noticeably extend handler latency. A consumer SHALL NOT roll back the originating action on failure; failures SHALL be logged and surfaced through admin-visible channels.
@@ -75,4 +57,27 @@ Variants like `MemberActivated(Member)` and `MemberUpdated { old, new }` SHALL c
 
 - **WHEN** a `MemberUpdated { old, new }` event reaches the Discord integration
 - **THEN** the integration SHALL compute role differences from the carried snapshots WITHOUT issuing additional DB reads
+
+### Requirement: Events for member operations are dispatched from MemberService
+
+For member-mutation operations (`activate`, `suspend`, `update`, `expire_now`, `update_discord_id`, `resend_verification`, `create`, `bulk_import`, etc.), the **service** in `src/service/member_service.rs` SHALL call `self.integration_manager.handle_event(...)` after the repo update. The handler in `src/web/portal/admin/members/` SHALL NOT dispatch member-mutation events directly; the handler's only job is HTTP shape (extract inputs, call the service, render the response).
+
+For payment operations, integration events (where applicable) SHALL be dispatched from `PaymentService` or `BillingService`. Payments do not produce `IntegrationEvent` variants directly today; admin alerts on billing failures are dispatched by `BillingService`.
+
+This change aligns with the CLAUDE.md "side-effects in services" rule — both member operations and payments now follow it.
+
+#### Scenario: New member-mutation method must dispatch events from the service
+
+- **WHEN** a contributor adds a new member-mutation method to `MemberService`
+- **THEN** the method MUST explicitly call `self.integration_manager.handle_event(...)` after the repo update; the handler does NOT (and SHALL NOT) dispatch events on its behalf
+
+#### Scenario: Handler skips event dispatch by design
+
+- **WHEN** a member-mutation handler is reviewed
+- **THEN** the handler SHALL NOT contain any `integration_manager.handle_event` call for member events; that responsibility lives in the service
+
+#### Scenario: BillingService dispatches AdminAlert on dunning
+
+- **WHEN** the billing runner records the configured threshold of consecutive failures for a member
+- **THEN** `BillingService` (not the handler) SHALL dispatch `IntegrationEvent::AdminAlert` so the admin-alert email integration sends a notification
 

--- a/openspec/specs/member-service-layout/spec.md
+++ b/openspec/specs/member-service-layout/spec.md
@@ -1,0 +1,41 @@
+# member-service-layout Specification
+
+## Purpose
+TBD - created by archiving change a27-split-member-service. Update Purpose after archive.
+## Requirements
+### Requirement: MemberService is a module directory with per-concern submodules
+
+`src/service/member_service.rs` SHALL be converted to a module directory at `src/service/member_service/` containing the following submodules:
+
+- `mod.rs` — `MemberService` struct, `new()` constructor, shared imports/re-exports
+- `status.rs` — `activate`, `suspend`, `expire_now`
+- `dues.rs` — `extend_dues`, `set_dues`
+- `updates.rs` — `update`, `update_discord_id`, `resend_verification`
+- `create.rs` — `create`, `bulk_import`, `send_welcome_email`
+- `queries.rs` — `audit_export`, `membership_type_name`
+- `events.rs` — `dispatch_member_updated` (private helper)
+
+Each submodule's methods live in `impl MemberService { ... }` blocks. The public API of `MemberService` SHALL be identical to the pre-split file.
+
+The autocoder MAY adjust the grouping if a different cut reads cleaner (e.g., extracting `bulk_import` to its own file given its 315-line size) as long as the size constraint below is satisfied.
+
+#### Scenario: No submodule exceeds 400 lines
+
+- **WHEN** the post-split files in `src/service/member_service/` are line-counted
+- **THEN** every file SHALL be ≤400 lines including tests
+
+#### Scenario: Public API is unchanged
+
+- **WHEN** the repo is built after the split
+- **THEN** every existing caller of `MemberService` SHALL compile without modification; no public method is removed, renamed, or has its visibility narrowed
+
+#### Scenario: Tests remain co-located with their methods
+
+- **WHEN** the tests for `activate`/`suspend`/`expire_now` are located after the split
+- **THEN** they SHALL live in `status.rs` (or whichever submodule houses those methods), NOT in a separate global test file
+
+#### Scenario: Existing tests still pass
+
+- **WHEN** `cargo test --features test-utils` is run after the split
+- **THEN** all tests that passed before SHALL still pass; no tests are lost or added by this refactor
+

--- a/openspec/specs/payment-admin-service/spec.md
+++ b/openspec/specs/payment-admin-service/spec.md
@@ -1,0 +1,59 @@
+# payment-admin-service Specification
+
+## Purpose
+TBD - created by archiving change a18-lift-refund-payment-admin. Update Purpose after archive.
+## Requirements
+### Requirement: PaymentAdminService is the single entrypoint for admin-driven payment mutations
+
+The system SHALL expose a `PaymentAdminService` at `src/service/payment_admin_service.rs` that owns the full side-effect chain (rate-limit enforcement, validation, atomic state transitions, external API calls, audit log, integration dispatch) for admin-driven payment mutations.
+
+Today the only such mutation is refund. As future admin-payment actions are added (e.g., partial refund, void, manual status adjustment), they SHALL extend this service rather than re-implementing the chain inline in handlers.
+
+#### Scenario: Handler calls the service, not the repo + collaborators
+
+- **WHEN** an admin POSTs to `/portal/admin/payments/:id/refund`
+- **THEN** the handler SHALL call `PaymentAdminService::refund(actor_id, payment_id, ip)` and render the response based on the returned `Result<RefundOutcome, RefundError>`; the handler SHALL NOT call `payment_repo.{claim_payment_for_refund, unclaim_refund, mark_refunded}`, `stripe_client.refund_payment`, `audit_service.log`, `integration_manager.handle_event`, or `money_limiter.check_and_record` directly
+
+### Requirement: Refund owns the rate-limit check, not the handler
+
+`PaymentAdminService::refund` SHALL take an `IpAddr` parameter and consult the `MoneyLimiter` instance held on the service struct. The handler SHALL NOT consult the limiter directly. This ensures a future caller (a test fixture, an alternative admin entry point) cannot accidentally skip the rate-limit by going around the handler.
+
+#### Scenario: Rate-limit exceeded returns RefundError::RateLimited
+
+- **WHEN** the same IP exceeds the money-limiter budget within the window and attempts a refund
+- **THEN** the service SHALL return `Err(RefundError::RateLimited)` before any DB or Stripe activity; the handler renders the "too many refund attempts" message
+
+### Requirement: Refund returns a typed RefundOutcome on success and typed RefundError on failure
+
+The service SHALL return `Result<RefundOutcome, RefundError>` where `RefundOutcome` carries the data the handler needs to render a success fragment (`amount_cents`, `stripe_refund_id: Option<String>`, `detail: String`, `payment_method`). `RefundError` is an enum covering every distinct user-facing failure mode (`RateLimited`, `PaymentNotFound`, `AlreadyRefunded`, `NotCompleted`, `WaivedNoRefund`, `StripeNotConfigured`, `NoStripeReferenceOnRecord`, `AnotherActorClaimedFirst`, `StripeApiError(String)`, `InternalDatabaseError(AppError)`, etc.).
+
+`RefundError::user_message()` SHALL return a `&'static str` for each variant. The handler renders that message in the failure fragment.
+
+#### Scenario: Stripe refund success returns outcome with refund id
+
+- **WHEN** a Stripe-method payment is successfully refunded
+- **THEN** the returned `RefundOutcome.stripe_refund_id` is `Some(ri_…)` and `detail` reads "Refunded $X.YZ via Stripe (refund ri_…)"
+
+#### Scenario: Manual refund success has no Stripe id
+
+- **WHEN** a Manual-method payment is refunded
+- **THEN** `stripe_refund_id` is `None` and `detail` reads "Marked $X.YZ manual payment as Refunded (no API call — refund the cash/check yourself)"
+
+#### Scenario: Stripe API error rolls back the claim
+
+- **WHEN** the claim succeeds but Stripe's refund API returns an error
+- **THEN** the service SHALL call `payment_repo.unclaim_refund(payment_id)` to revert the Completed→Refunded flip, and return `Err(RefundError::StripeApiError(message))`; a subsequent retry can re-claim the row
+
+### Requirement: Service inherits existing failure semantics
+
+`PaymentAdminService::refund` SHALL preserve the existing semantics:
+
+- Audit-log insert failure: logged via `tracing`, swallowed.
+- Integration dispatch failure: per-integration failures logged inside `IntegrationManager`; the call returns success.
+- Repository failure: propagated as `RefundError::InternalDatabaseError`.
+
+#### Scenario: Integration dispatch failure does not roll back the refund
+
+- **WHEN** the refund succeeds at the repo + Stripe level but the AdminAlert dispatch fails
+- **THEN** the service SHALL return `Ok(outcome)`; the integration failure SHALL be logged inside the integration layer
+

--- a/openspec/specs/payment-recording/spec.md
+++ b/openspec/specs/payment-recording/spec.md
@@ -3,45 +3,37 @@
 ## Purpose
 TBD - created by archiving change document-existing-architecture. Update Purpose after archive.
 ## Requirements
-### Requirement: Two payment-recording entry points: PaymentService::record_manual and WebhookDispatcher
-
-Payments SHALL be recorded via exactly two entry points:
-
-- **`PaymentService::record_manual`** — for non-Stripe payments (Cash, Check, Waived, Other). The service SHALL reject `PaymentMethod::Stripe` with a `BadRequest`; Stripe payments SHALL go through the webhook flow.
-- **`WebhookDispatcher::handle_*`** — for Stripe payments (PaymentIntent, CheckoutSession, Invoice). Verified-signature inbound, idempotency-claimed, dispatched per event type.
-
-Both entry points SHALL persist via `payment_repo.create(...)`. Direct `payment_repo.create` calls from handlers or services other than these two SHALL be forbidden.
-
-#### Scenario: record_manual rejects Stripe method
-
-- **WHEN** a caller invokes `PaymentService::record_manual` with `PaymentMethod::Stripe`
-- **THEN** the call SHALL return `BadRequest("Stripe payments are recorded via StripeClient, not record_manual")`
-
-#### Scenario: Webhook handler is the only Stripe-payment writer
-
-- **WHEN** a Stripe payment-succeeded event arrives
-- **THEN** the webhook dispatcher's per-type handler SHALL construct the `Payment` value and call `payment_repo.create`; no other code path SHALL write Stripe payments
-
 ### Requirement: PaymentService::record_manual emits the audit-log entry
 
-`record_manual` SHALL emit an audit-log entry via `audit_service.log` after a successful repo write, using a centralized `audit_action(method, kind)` mapping that produces the action string. The mapping SHALL be:
+`record_manual` SHALL emit an audit-log entry via `audit_service.log` after a
+successful repo write, using a centralized `audit_action(method, kind)`
+mapping that produces the action string. The mapping SHALL be:
 
 - `(Waived, _)` → `"waive_dues"`
 - `(_, Membership)` → `"manual_payment"`
 - `(_, Donation { .. })` → `"manual_donation"`
 - `(_, Other)` → `"manual_other"`
 
-Centralization SHALL prevent the four sites that previously duplicated this from drifting.
+Centralization SHALL prevent the four sites that previously duplicated this
+from drifting.
 
 #### Scenario: Cash dues payment audits as manual_payment
 
-- **WHEN** `record_manual` records a `(PaymentMethod::Cash, PaymentKind::Membership)` payment
+- **WHEN** `record_manual` records a `(PaymentMethod::Cash,
+  PaymentKind::Membership)` payment
 - **THEN** the emitted audit row SHALL have `action = "manual_payment"`
 
 #### Scenario: Waived dues audits as waive_dues
 
-- **WHEN** `record_manual` records a `(PaymentMethod::Waived, PaymentKind::Membership)` payment
+- **WHEN** `record_manual` records a `(PaymentMethod::Waived,
+  PaymentKind::Membership)` payment
 - **THEN** the emitted audit row SHALL have `action = "waive_dues"`
+
+#### Scenario: Cash donation audits as manual_donation
+
+- **WHEN** `record_manual` records a `(PaymentMethod::Cash,
+  PaymentKind::Donation { .. })` payment
+- **THEN** the emitted audit row SHALL have `action = "manual_donation"`
 
 ### Requirement: Membership-kind payments trigger dues-extension and reschedule (soft-fail)
 
@@ -59,27 +51,35 @@ Both calls SHALL be soft-fail: errors are logged via `tracing` but do NOT roll b
 
 ### Requirement: Validation at the service boundary
 
-`record_manual` SHALL validate at entry: `amount_cents >= 0`, `amount_cents <= MAX_PAYMENT_CENTS`, member exists, and donation-campaign id exists when supplied. These checks defend against forged JSON / stale forms even though the UI normally produces valid input.
+`record_manual` SHALL validate at entry: `amount_cents >= 0`,
+`amount_cents <= MAX_PAYMENT_CENTS`, member exists, and donation-campaign id
+exists when supplied. These checks defend against forged JSON / stale forms
+even though the UI normally produces valid input.
 
 #### Scenario: Negative amount rejected
 
 - **WHEN** `record_manual` receives `amount_cents = -100`
-- **THEN** it SHALL return `BadRequest`
+- **THEN** it SHALL return `BadRequest` AND the `payments` table SHALL
+  remain empty (no row was persisted before the guard fired)
 
 #### Scenario: Amount over cap rejected
 
 - **WHEN** `record_manual` receives an amount exceeding `MAX_PAYMENT_CENTS`
-- **THEN** it SHALL return `BadRequest` naming the cap
+- **THEN** it SHALL return `BadRequest` whose message names the cap
+  in whole dollars
 
 #### Scenario: Unknown member rejected
 
 - **WHEN** `record_manual` receives a `member_id` not present in `members`
-- **THEN** it SHALL return `BadRequest("member <id> not found")`
+- **THEN** it SHALL return `BadRequest` whose message includes the
+  unknown id
 
 #### Scenario: Donation with stale campaign id rejected
 
-- **WHEN** `record_manual` receives `PaymentKind::Donation { campaign_id: Some(stale_id) }` where the campaign no longer exists
-- **THEN** the call SHALL return `BadRequest`; orphan donation rows SHALL NOT be created
+- **WHEN** `record_manual` receives `PaymentKind::Donation { campaign_id:
+  Some(stale_id) }` where the campaign no longer exists
+- **THEN** the call SHALL return `BadRequest` AND the `payments` table
+  SHALL contain no row for this attempt (no orphan donation row is created)
 
 ### Requirement: Refund flow is the third write path with handler-emitted audit
 
@@ -89,4 +89,36 @@ Both calls SHALL be soft-fail: errors are logged via `tracing` but do NOT roll b
 
 - **WHEN** an admin refunds a payment whose `external_id` is `Some(StripeRef::PaymentIntent(...))`
 - **THEN** the handler SHALL call Stripe's refund API, update the payment row, and emit the audit-log entry directly
+
+### Requirement: Payment-recording entry points are explicitly enumerated
+
+Payments SHALL be recorded via exactly three entry points:
+
+- **`PaymentService::record_manual`** — for non-Stripe payments (Cash, Check, Waived, Other). Operator-initiated via the admin UI. The service SHALL reject `PaymentMethod::Stripe` with a `BadRequest`; Stripe payments SHALL go through one of the other two entry points.
+- **`WebhookDispatcher::handle_*`** — for Stripe-initiated events: customer paid an invoice, customer completed a checkout session, payment-intent succeeded. Inbound to Coterie, verified-signature, idempotency-claimed, dispatched per event type.
+- **`BillingService::process_scheduled_payment`** — for Coterie-initiated auto-renew charges against a saved card. The scheduled payment row is the Coterie-side trigger; the Stripe charge is a direct API call (not a webhook); on charge success, the `Payment` row is created from the charge result.
+
+All three entry points SHALL persist via `payment_repo.create(...)`. Direct `payment_repo.create` calls from handlers or services OTHER than these three SHALL be forbidden. Adding a fourth entry point requires updating this spec.
+
+Why three, not two: `BillingService::process_scheduled_payment` doesn't fit either of the other two — it's not operator-initiated (so not `record_manual`) and there's no inbound webhook (the charge is initiated by Coterie's scheduler, not Stripe). The third entry point reflects this legitimately distinct shape.
+
+#### Scenario: record_manual rejects Stripe method
+
+- **WHEN** a caller invokes `PaymentService::record_manual` with `PaymentMethod::Stripe`
+- **THEN** the call SHALL return `BadRequest("Stripe payments are recorded via StripeClient, not record_manual")`
+
+#### Scenario: Webhook handler is the only writer for Stripe-inbound events
+
+- **WHEN** a Stripe payment-succeeded webhook event arrives
+- **THEN** the webhook dispatcher's per-type handler SHALL construct the `Payment` value and call `payment_repo.create`; no other code path SHALL write payments from Stripe-inbound events
+
+#### Scenario: Auto-renew charges write payments via BillingService
+
+- **WHEN** a scheduled payment is processed and the saved-card charge succeeds
+- **THEN** `BillingService::process_scheduled_payment` SHALL construct the `Payment` value and call `payment_repo.create`; the resulting payment row SHALL be linked to the scheduled-payment row and audited
+
+#### Scenario: A fourth entry point requires a spec amendment
+
+- **WHEN** a contributor adds a new code path that records a payment outside the three listed entry points
+- **THEN** the PR SHALL be rejected pending an amendment to this requirement listing the new entry point; the rule exists to prevent accidental audit/event-skipping by ad-hoc payment-row writers
 

--- a/openspec/specs/portal-payments-handlers-layout/spec.md
+++ b/openspec/specs/portal-payments-handlers-layout/spec.md
@@ -1,0 +1,33 @@
+# portal-payments-handlers-layout Specification
+
+## Purpose
+TBD - created by archiving change a33-split-portal-payments-handlers. Update Purpose after archive.
+## Requirements
+### Requirement: Portal payments handlers are organized into focused submodules
+
+`src/web/portal/payments.rs` SHALL be converted to a module directory at `src/web/portal/payments/` with the following submodules:
+
+- `mod.rs` — router + module declarations
+- `views.rs` — `payments_page`, `payments_list_api`, `payments_summary_api`, `dues_status_api`, `next_due_api`
+- `flow.rs` — `payment_success_page`, `payment_cancel_page`, `payment_new_page`
+- `checkout.rs` — `checkout_api`, `charge_saved_card_api`
+- `saved_cards.rs` — `payment_methods_page`, `update_auto_renew_api`, `saved_cards_html_api`, `delete_card_api`, `set_default_card_api`
+- `receipts.rs` — `receipts_page`, `receipt_page`
+
+Each handler's visibility SHALL be the narrowest that satisfies the router's needs (`pub(super)` preferred where it works; `pub` otherwise).
+
+#### Scenario: No submodule exceeds 300 lines
+
+- **WHEN** the post-split files in `src/web/portal/payments/` are line-counted
+- **THEN** every file SHALL be ≤300 lines
+
+#### Scenario: All routes still resolve to the same handlers
+
+- **WHEN** integration tests that hit portal payment routes are run
+- **THEN** they SHALL pass without modification; URL → handler resolution is unchanged
+
+#### Scenario: Rate limiter remains wired on money-moving endpoints
+
+- **WHEN** the router for `/portal/api/payments/checkout` and `/portal/api/payments/charge-saved` is inspected after the split
+- **THEN** both routes SHALL still apply the `money_limiter` layer as required by the `rate-limiting` capability; the limiter wiring SHALL NOT regress as a side-effect of the split
+

--- a/openspec/specs/provisioning-wizard/spec.md
+++ b/openspec/specs/provisioning-wizard/spec.md
@@ -1,0 +1,199 @@
+# provisioning-wizard Specification
+
+## Purpose
+TBD - created by archiving change a24-provisioning-wizard. Update Purpose after archive.
+## Requirements
+### Requirement: coterie-provision is the primary first-deploy path
+
+The system SHALL ship a Rust binary `coterie-provision` (alongside `coterie` and `create_admin` in the release tarball) that performs an end-to-end Coterie install on a fresh Debian 13 host. The binary's `install` subcommand performs the wizard flow.
+
+A thin bash bootstrap `deploy/provision.sh` SHALL exist in the repo, curl-able from `master`. The bootstrap SHALL run under `set -euo pipefail`, refuse if not root, refuse if not Debian, fetch the latest stable release tag (or accept `--tag`), download the `coterie-provision-<tag>-x86_64-unknown-linux-musl.tar.gz` asset, verify it against the matching `.sha256` asset, extract `coterie-provision`, and `exec` it with `install` and any pass-through flags. The bootstrap SHALL be short enough (~50 lines) that a curious operator can read it before running.
+
+From operator perspective, a single command sequence (curl + bash) takes a clean box to a running Coterie instance with a first admin already created, .env populated, optional integrations configured, and (if chosen) Caddy serving with TLS.
+
+The `README.md` deploy section SHALL recommend the wizard as the primary deploy path. The curl-and-bash one-liner SHALL appear inline. Any prior manual-deploy steps in the README are demoted below the wizard (under an "Advanced / manual" heading) or replaced with a link to `DEPLOY-DIGITALOCEAN.md`. A new operator reading the README SHALL encounter the wizard before any manual alternative.
+
+#### Scenario: First-time install on a fresh Debian 13 droplet
+
+- **WHEN** an operator provisions a new Debian 13 droplet, curls the bootstrap, and runs it interactively answering the prompts
+- **THEN** at the end: `/opt/coterie/coterie` is running under systemd, `/var/lib/coterie/coterie.db` exists with a first-admin row, `/opt/coterie/.env` is populated with the supplied values + a generated session secret, and a `GET http://127.0.0.1:8080/health` returns 200 with JSON (not a 303 to /setup)
+
+#### Scenario: Idempotent re-run after a partial failure
+
+- **WHEN** an operator re-runs the wizard after a failure mid-way through
+- **THEN** the wizard SHALL detect existing state (`.env` already populated, admin already exists, systemd unit already installed) and prompt before clobbering each; the operator can choose to skip steps that already succeeded
+
+#### Scenario: --dry-run mode shows the plan
+
+- **WHEN** the operator invokes `coterie-provision install --dry-run`
+- **THEN** the wizard SHALL print every step it would take (with the actual command lines + the .env content + the Caddyfile substitution result) WITHOUT executing any of them; no side effects occur
+
+#### Scenario: README points new operators at the wizard
+
+- **WHEN** a new operator reads the README's deploy section
+- **THEN** the first thing presented SHALL be the wizard (with the curl-and-bash one-liner); manual deploy instructions, if retained, SHALL appear below under an "Advanced / manual" heading or as a link to `DEPLOY-DIGITALOCEAN.md`
+
+### Requirement: Wizard offers version selection with safe defaults
+
+The wizard SHALL allow the operator to choose which Coterie version to install. The default SHALL be the **latest stable release** (most recent release where `prerelease: false` in the GitHub API response). Operators can optionally view older stable releases (for rollback) or prereleases (for installing dev builds).
+
+The release workflow (`.github/workflows/release.yml`) SHALL mark tags matching `^v\d+\.\d+\.\d+$` as stable releases and all other tags (e.g. `v1.0.0dev`, `v1.0.0-rc1`, `v1.0.0alpha`) with `prerelease: true`. This ensures GitHub's API correctly classifies each tag and the wizard's "latest stable" semantics work cleanly.
+
+#### Scenario: Default is latest stable
+
+- **WHEN** the wizard runs and the operator accepts the default version selection
+- **THEN** the latest tag matching `^v\d+\.\d+\.\d+$` SHALL be selected; dev/alpha/beta/rc tags SHALL NOT be picked as default
+
+#### Scenario: Operator can pin a specific stable version
+
+- **WHEN** the operator selects an older stable release from the menu (e.g. for rollback)
+- **THEN** the wizard SHALL pass that tag to `release-deploy.sh` for installation
+
+#### Scenario: Operator can opt into prereleases explicitly
+
+- **WHEN** the operator selects "show all releases including prereleases" from the menu
+- **THEN** the wizard SHALL list all recent releases (stable + prerelease) and let the operator pick a dev/rc tag
+
+#### Scenario: Env-var or flag override works
+
+- **WHEN** `COTERIE_PROVISION_VERSION=v1.0.0` is set OR `--version v1.0.0` is passed
+- **THEN** the wizard SHALL skip the version-selection prompt and use the specified tag verbatim
+
+#### Scenario: release.yml correctly classifies dev tags
+
+- **WHEN** a tag matching `*dev`, `*alpha`, `*beta`, or `*rc*` is pushed
+- **THEN** the published GitHub Release SHALL have `prerelease: true`; the `/releases/latest` API SHALL NOT return it; `release-deploy.sh` (no args) SHALL skip it
+
+### Requirement: All prompts have a non-interactive equivalent
+
+Every interactive prompt SHALL check for a `COTERIE_PROVISION_<NAME>` environment variable AND a matching `--flag` argument first, and if either is set, skip the prompt. If every required input is supplied via env or flag, the wizard runs without prompts (suitable for IaC pipelines).
+
+The binary's `--help` output SHALL enumerate all env vars and flags.
+
+Required inputs (only some — the full list is in `--help`):
+- `COTERIE_PROVISION_ORG_NAME` / `--org-name`
+- `COTERIE_PROVISION_PORTAL_DOMAIN` / `--portal-domain`
+- `COTERIE_PROVISION_ADMIN_EMAIL` / `--admin-email`
+- `COTERIE_PROVISION_ADMIN_USERNAME` / `--admin-username`
+- `COTERIE_PROVISION_ADMIN_FULL_NAME` / `--admin-full-name`
+- `COTERIE_PROVISION_ADMIN_PASSWORD` / `--admin-password` (env preferred for secrets)
+- `COTERIE_PROVISION_ENABLE_STRIPE` / `--enable-stripe` (`true`/`false`)
+- `COTERIE_PROVISION_ENABLE_CADDY` / `--enable-caddy` (`true`/`false`)
+
+Optional, conditional on enabling integrations: Stripe / Discord / UniFi credential vars and flags.
+
+#### Scenario: Fully scripted run for IaC
+
+- **WHEN** the operator exports every required env var and runs `coterie-provision install --no-prompt`
+- **THEN** the wizard SHALL execute without any interactive prompts and complete the same end state as the interactive flow
+
+#### Scenario: Mixed interactive + non-interactive run
+
+- **WHEN** the operator sets some env vars (e.g. `COTERIE_PROVISION_ORG_NAME`, `COTERIE_PROVISION_PORTAL_DOMAIN`) but not others
+- **THEN** the wizard SHALL skip the prompts whose env vars/flags are set and prompt only for the unset ones
+
+#### Scenario: --no-prompt errors when required inputs are missing
+
+- **WHEN** `--no-prompt` is passed but a required env var or flag is missing
+- **THEN** the wizard SHALL exit non-zero with a clear message listing every missing required input
+
+### Requirement: Admin password handling does not leak
+
+The wizard SHALL handle the admin password such that it never appears in:
+- The shell's process listing (no `--password "..."` on a command line to create_admin)
+- Any log file emitted by the wizard or by any process it invokes
+- Debug output (the password is wrapped in `secrecy::Secret<String>` whose `Debug` impl prints `[REDACTED]`)
+- The .env file (passwords are hashed into the DB by `create_admin`, not stored as env vars)
+
+The password is passed to `create_admin` via a `--password-file` whose contents are written with mode 0600 and removed (via `tempfile::NamedTempFile`'s `Drop` impl, plus an explicit overwrite-with-zeros step) immediately after `create_admin` returns, regardless of whether create_admin succeeded.
+
+#### Scenario: Password is in a mode-0600 tempfile briefly
+
+- **WHEN** the wizard reaches the create_admin step
+- **THEN** it SHALL write the password to a `tempfile`-managed file with mode 0600, invoke `create_admin --password-file <path>`, then overwrite-and-unlink the file regardless of the exit code
+
+#### Scenario: Password does not appear in process listings during create_admin
+
+- **WHEN** another user runs `ps aux` while create_admin is in progress
+- **THEN** the password SHALL NOT be visible in any process argv
+
+### Requirement: Caddyfile generation includes the log-directory fix
+
+When the operator chooses to install Caddy, the wizard SHALL:
+
+1. Read `/opt/coterie/deploy/Caddyfile.example` (placed there by `release-deploy.sh`)
+2. Substitute the operator's portal domain in place of `coterie.example.com`
+3. Substitute the operator's marketing domain (or remove the second site block if no marketing domain was supplied) — substitution logic lives in a pure function `render_caddyfile` with golden test coverage
+4. `mkdir -p /var/log/caddy && chown -R caddy:caddy /var/log/caddy` BEFORE the Caddy reload (this was the root cause of one of this session's deploy failures)
+5. Write the result to `/etc/caddy/Caddyfile`
+6. Run `caddy validate --config /etc/caddy/Caddyfile`; on failure, surface the error with full context (treat as a wizard bug, not an operator-fixable input issue)
+7. `systemctl reload caddy` (or restart if the previous config was broken)
+
+#### Scenario: Fresh Caddy install includes log-dir setup
+
+- **WHEN** the wizard installs Caddy on a host where `/var/log/caddy/` doesn't exist
+- **THEN** the wizard SHALL `mkdir -p` it and `chown -R caddy:caddy` it BEFORE attempting Caddy reload, so the "log writer permission denied" failure from this session doesn't reoccur
+
+#### Scenario: render_caddyfile is unit-tested
+
+- **WHEN** the test suite runs
+- **THEN** golden tests SHALL cover `render_caddyfile` for: portal-only (no marketing domain), portal + marketing, edge cases (domain with hyphens, subdomain depth); the test SHALL NOT require running `caddy validate` (which isn't available in the autocoder sandbox)
+
+### Requirement: Wizard uses create_admin to bootstrap before service start
+
+The wizard SHALL invoke `/opt/coterie/create_admin` with the supplied credentials AFTER `release-deploy.sh` has placed the binary and BEFORE `systemctl start coterie`. This sequence closes the unauthenticated /setup hijack window — by the time Coterie binds port 8080, an admin already exists; the setup-redirect middleware forwards normally and /setup is unreachable.
+
+#### Scenario: Service starts with admin already present
+
+- **WHEN** the wizard completes the create_admin step and then runs `systemctl enable --now coterie`
+- **THEN** Coterie starts with an admin row in `members` already; the `admin_exists_observed` cache populates on the first request; /setup redirects to /login from the moment the service is reachable
+
+### Requirement: Side-effecting code is behind testable traits
+
+All side-effecting operations (process invocation, filesystem read/write/chmod/chown, HTTP calls) SHALL go through `SystemCommand` and `FileSystem` (or similar) trait abstractions. Production code uses `Real*` implementations that call `std::process::Command`, `std::fs`, and `reqwest`. Test code uses `Fake*` implementations that record calls and return canned responses.
+
+This requirement exists so the autocoder can fully validate the wizard via `cargo test` without spinning up VMs or invoking real apt-get/systemctl.
+
+#### Scenario: Integration test drives install end-to-end with fakes
+
+- **WHEN** the test `tests/install_flow.rs` runs `coterie-provision install` against `FakeSystem` and `FakeFs`
+- **THEN** the test SHALL assert: the expected commands were invoked in the expected order, the .env file's would-be contents match a golden snapshot, the Caddyfile's would-be contents match a golden snapshot, and rerunning the same flow against the same fakes produces the same idempotent end state
+
+#### Scenario: cargo test passes in the autocoder sandbox
+
+- **WHEN** the autocoder runs `cargo test -p coterie-provision`
+- **THEN** all tests SHALL pass without requiring shellcheck, a VM, or any tooling outside the standard Rust toolchain
+
+### Requirement: Wizard offers a test-mode-or-live-mode choice
+
+The `coterie-provision install` subcommand SHALL prompt the operator to choose between test mode and live mode when configuring Stripe. The prompt SHALL be presented if and only if Stripe is being enabled. Default selection: **live mode** (matching the `a24` wizard's baseline behavior).
+
+If test mode is selected:
+- The wizard SHALL collect test-mode Stripe credentials (`pk_test_*`, `sk_test_*`, test webhook signing secret `whsec_…`). Prefix validation reuses `a24`'s `validate_prefix` helper.
+- The wizard SHALL configure `.env` with `DATABASE_URL` pointing at `coterie-test.db`.
+- The wizard MAY (operator's choice) ALSO collect live-mode credentials and stash them in `/opt/coterie/.env.live` (chmod 0640, owned by `coterie`, written via the `FileSystem` trait) for the future switchover.
+- After the wizard completes, a verification checklist SHALL be printed describing the manual flows to test and the command to run when ready to switch to live mode.
+
+If live mode is selected:
+- Wizard behavior is identical to the `a24` baseline (collects live credentials, `coterie.db` is the database).
+
+#### Scenario: Test mode selected, switchover guidance printed
+
+- **WHEN** the wizard runs with test mode selected
+- **THEN** the final output SHALL include a verification checklist (suggested flows + how to run each) and the command line to invoke `coterie-provision switch-stripe-to-live` when ready
+
+#### Scenario: Live mode selected behaves identically to a24
+
+- **WHEN** the wizard runs with live mode selected
+- **THEN** the resulting Coterie instance SHALL match the `a24` baseline behavior — `.env` configured with live credentials, `coterie.db` as the database, no `coterie-test.db` or `.env.live` artifacts on disk
+
+#### Scenario: Env-var or flag override skips the test-or-live prompt
+
+- **WHEN** `COTERIE_PROVISION_STRIPE_MODE=test` (or `=live`) is set, OR `--stripe-mode test` (or `live`) is passed
+- **THEN** the wizard SHALL skip the prompt and use the specified mode
+
+#### Scenario: Test-mode path is covered by integration test
+
+- **WHEN** the autocoder runs `cargo test -p coterie-provision`
+- **THEN** an integration test SHALL drive the install subcommand in test mode against `FakeSystem` and `FakeFs`, asserting that `.env` is written with `coterie-test.db` as the DATABASE_URL, `.env.live` is created if live creds were also supplied, and the verification checklist text appears in the captured stdout
+

--- a/openspec/specs/recurring-billing/spec.md
+++ b/openspec/specs/recurring-billing/spec.md
@@ -45,3 +45,46 @@ The runner SHALL ensure that running the same tick twice does not double-charge 
 - **WHEN** the runner re-runs a few minutes after a successful charge
 - **THEN** the previously-charged member SHALL be excluded from the candidate set
 
+### Requirement: BillingService is a flat container, not a delegating facade
+
+`BillingService` SHALL be a struct holding three public fields — one per sub-service — and SHALL NOT carry delegation methods that forward to those sub-services. The fields SHALL be:
+
+- `pub auto_renew: AutoRenew`
+- `pub notifications: Notifications`
+- `pub expiration: Expiration`
+
+Callers SHALL reach sub-service methods via direct field access (e.g., `billing_service.auto_renew.run_billing_cycle()`). Adding a new method to a sub-service SHALL NOT require any change to `BillingService` itself.
+
+#### Scenario: New auto-renew method needs no facade update
+
+- **WHEN** a contributor adds a new method to `AutoRenew` (e.g., a one-shot reconcile)
+- **THEN** the method SHALL be reachable from external callers as `billing_service.auto_renew.<method>(...)` immediately, without adding a forwarder to `BillingService`
+
+#### Scenario: BillingService impl block is constructor-only
+
+- **WHEN** a contributor inspects `impl BillingService { ... }`
+- **THEN** the only method SHALL be `new(...)` (the constructor that wires the three sub-services); there SHALL be no `pub async fn enable_auto_renew`, `pub async fn run_billing_cycle`, or any other forwarding method
+
+### Requirement: Sub-service types and modules are public
+
+`AutoRenew`, `Notifications`, and `Expiration` (and their containing modules `auto_renew`, `notifications`, `expiration` under `src/service/billing_service/`) SHALL be `pub` so that external callers can hold typed references via `BillingService`'s public fields. The sub-services SHALL continue to be constructed exclusively inside `BillingService::new`; no external code SHALL construct them directly.
+
+#### Scenario: Sub-service paths resolve from external callers
+
+- **WHEN** a caller writes `let svc: &auto_renew::AutoRenew = &state.billing_service.auto_renew;`
+- **THEN** the path SHALL resolve and the borrow SHALL compile
+
+#### Scenario: Sub-services are still constructed only inside BillingService::new
+
+- **WHEN** any code outside `BillingService::new` attempts to construct an `AutoRenew`, `Notifications`, or `Expiration`
+- **THEN** convention prohibits this; the sub-services SHALL remain owned-by-value inside the parent `BillingService`
+
+### Requirement: Method names on sub-services are unchanged by the facade flattening
+
+The flattening of `BillingService` SHALL NOT rename any method. `auto_renew.enable_auto_renew(...)`, `auto_renew.run_billing_cycle(...)`, `notifications.send_dues_reminders(...)`, `expiration.check_expired_members(...)`, and the rest SHALL keep the names they had before the change. Renaming methods (e.g., `enable_auto_renew` → `enable`) is a separate concern.
+
+#### Scenario: Method names survive the change byte-for-byte
+
+- **WHEN** a contributor diffs the post-change sub-service files against the pre-change ones
+- **THEN** method signatures (name + parameter list + return type) SHALL be unchanged; only call-site access paths in the rest of the codebase SHALL change
+

--- a/openspec/specs/repository-contracts/spec.md
+++ b/openspec/specs/repository-contracts/spec.md
@@ -5,17 +5,36 @@ TBD - created by archiving change document-existing-architecture. Update Purpose
 ## Requirements
 ### Requirement: Repository methods are declared on a trait
 
-Each repository SHALL have a trait declared in `src/repository/mod.rs` and an implementation in the matching `<entity>_repository.rs`. New repository methods SHALL be added to the trait, not just the impl, so callers depend on the trait.
+Each repository SHALL have a trait declared in its per-file module (e.g., `MemberRepository` in `src/repository/member_repository.rs`) alongside the matching Sqlite implementation. The trait SHALL be re-exported from `src/repository/mod.rs` via `pub use` so external callers can continue to import it as `crate::repository::<TraitName>`.
 
-#### Scenario: New method is added to trait first
+`src/repository/mod.rs` SHALL contain only `pub mod` declarations and `pub use` re-exports — no trait declarations, no impl blocks, no auxiliary types. Auxiliary types (e.g., `MemberQuery`, `MemberSortField`, `SortOrder`, `MonthlyRevenue`) SHALL live in the same per-file module as the trait that uses them.
+
+New repository methods SHALL be added to the trait, not just the impl, so callers depend on the trait.
+
+#### Scenario: New method is added to trait first, in the per-file module
 
 - **WHEN** a contributor adds a new repository method
-- **THEN** the method SHALL be declared on the trait and implemented in the impl; tests and callers SHALL hold the trait-typed reference
+- **THEN** the method SHALL be declared on the trait (located in the per-file module, e.g., `src/repository/member_repository.rs`) and implemented in the impl in the same file; tests and callers SHALL hold the trait-typed reference
+
+#### Scenario: mod.rs is a module index, not a trait dump
+
+- **WHEN** a contributor inspects `src/repository/mod.rs`
+- **THEN** the file SHALL contain only `pub mod <module>;` declarations and `pub use <module>::{...};` re-exports; it SHALL NOT contain any `pub trait`, `pub struct`, `pub enum`, or `impl` block
 
 #### Scenario: Tests can substitute a fake impl
 
 - **WHEN** a test wants to substitute a repository
-- **THEN** the consumer SHALL hold a trait object (or generic) so a fake or in-memory impl can be substituted
+- **THEN** the consumer SHALL hold a trait object (or generic) so a fake or in-memory impl can be substituted; the trait import path (`use crate::repository::<TraitName>;`) SHALL continue to resolve via the re-export
+
+#### Scenario: Auxiliary types live next to the trait that uses them
+
+- **WHEN** a contributor inspects `MemberQuery`, `MemberSortField`, `SortOrder`
+- **THEN** they SHALL be defined in `src/repository/member_repository.rs` alongside `MemberRepository`; they SHALL be re-exported from `mod.rs` so `crate::repository::MemberQuery` continues to resolve
+
+#### Scenario: Adding a new repository follows the per-file pattern
+
+- **WHEN** a contributor adds a new repository (e.g., for a new entity)
+- **THEN** the trait, the Sqlite impl, the row struct, and any auxiliary types SHALL all live in a single `<entity>_repository.rs` file; `mod.rs` SHALL gain a `pub mod` line and a `pub use` line, nothing more
 
 ### Requirement: Strongly-typed query/sort inputs prevent stringly-typed mistakes
 

--- a/openspec/specs/routing-architecture/spec.md
+++ b/openspec/specs/routing-architecture/spec.md
@@ -57,3 +57,149 @@ State-changing admin actions SHALL emit their audit-log entries and integration 
 - **WHEN** a new admin action is added that calls an existing service method
 - **THEN** the audit-log entry and integration event for that action SHALL be emitted by the service, not by the handler, so a hypothetical second caller of the same service method gets identical side-effects
 
+### Requirement: Setup-redirect check is process-cached after first positive observation
+
+`AppState` SHALL hold an `admin_exists_observed: Arc<AtomicBool>` flag, initialized to `false`. The `require_setup` middleware SHALL consult this flag before querying the database; once set to `true`, the middleware SHALL forward the request without querying. The middleware SHALL set the flag to `true` the first time it observes any admin row in the database.
+
+The flag SHALL be process-local; a multi-process deployment SHALL have each process independently arm its own cache. The flag SHALL be sticky for the lifetime of the process — it SHALL NOT be cleared by any application-level operation. Operators who manually remove admin status from every member via direct SQL SHALL restart the server to re-arm the setup-redirect path.
+
+The setup-wizard handler (POST `/setup`) SHALL set the flag to `true` immediately after successfully creating the first admin, so the very next request bypasses the redundant DB query.
+
+#### Scenario: First request after setup observes admin and arms cache
+
+- **WHEN** an instance has just completed first-boot setup and the very next request arrives at the middleware
+- **THEN** the middleware SHALL forward the request, AND `admin_exists_observed` SHALL be `true` afterward (set proactively by the setup-wizard handler or by the middleware itself on a positive DB lookup)
+
+#### Scenario: Subsequent requests skip the DB query
+
+- **WHEN** `admin_exists_observed` is `true` and a non-static, non-setup-prefix request arrives
+- **THEN** the middleware SHALL forward the request without running `SELECT 1 FROM members WHERE is_admin = 1 LIMIT 1`
+
+#### Scenario: First-boot redirect still fires before any admin exists
+
+- **WHEN** a fresh-install instance with no admin yet receives a request to a non-static, non-setup-prefix path
+- **THEN** the middleware SHALL run the DB query, observe no admin, and respond with a redirect to `/setup`; `admin_exists_observed` SHALL remain `false`
+
+#### Scenario: Concurrent first-boot requests converge
+
+- **WHEN** two concurrent requests reach the middleware before any admin exists, while a third request is concurrently completing the setup-wizard handler
+- **THEN** each first-boot request SHALL independently consult the DB, the wizard's admin creation SHALL be serialized by `setup_lock`, and after the wizard completes the next request SHALL observe `admin_exists_observed = true` (set either by the wizard's proactive store or by the middleware's own observation)
+
+#### Scenario: Direct-SQL admin removal does not re-trigger redirect without restart
+
+- **WHEN** an operator directly clears `is_admin` on every member row via DB tooling outside the application
+- **THEN** the cached `admin_exists_observed = true` SHALL persist; subsequent requests SHALL continue to forward (not redirect to `/setup`); recovery SHALL require a server restart so the flag re-initializes to `false`
+
+### Requirement: AppState exposes FromRef impls for granular extraction
+
+`AppState` SHALL expose `axum::extract::FromRef<AppState>` implementations for every constituent service, repository, and piece of infrastructure that a handler might reasonably extract. Adding a new field to `AppState` or `ServiceContext` SHALL also include a `FromRef<AppState>` impl in the same change.
+
+The impls SHALL all live in `src/api/state.rs` (or a clearly-scoped sub-module of it) so that "what `AppState` exposes" can be answered by reading a single file.
+
+Handlers MAY continue to use `State<AppState>` extraction; this requirement does not mandate a particular handler style. It only requires that the FromRef machinery is available so granular extraction is possible.
+
+#### Scenario: Every field is extractable
+
+- **WHEN** a handler writes `State(svc): State<Arc<dyn SomeRepository>>` against a router holding `AppState`
+- **THEN** the extraction SHALL resolve via `FromRef<AppState>` to `state.service_context.<field>.clone()` (or the analogous path for non-`service_context` fields)
+
+#### Scenario: A new field on AppState gets a FromRef impl
+
+- **WHEN** a contributor adds a new service, repo, or infrastructure component to `AppState` (or to `ServiceContext` reachable through `AppState`)
+- **THEN** the same change SHALL include a `FromRef<AppState>` impl for it in `src/api/state.rs`
+
+#### Scenario: Existing State<AppState> handlers still compile
+
+- **WHEN** a handler authored before this change uses `State(state): State<AppState>`
+- **THEN** that handler SHALL continue to compile and run unchanged — the FromRef impls coexist with the old extraction shape
+
+### Requirement: Distinct RateLimiter instances are extractable via newtypes
+
+The two `RateLimiter` instances on `AppState` (`login_limiter` and `money_limiter`) SHALL each be wrapped in a newtype (`LoginLimiter`, `MoneyLimiter`) so they can be disambiguated as `State<LoginLimiter>` vs. `State<MoneyLimiter>` extractors. A bare `FromRef<AppState> for RateLimiter` SHALL NOT exist (it would be ambiguous between the two instances).
+
+#### Scenario: Login limiter extracts via its newtype
+
+- **WHEN** a handler writes `State(limiter): State<LoginLimiter>`
+- **THEN** the extraction SHALL resolve to a clone of `state.login_limiter` wrapped in the `LoginLimiter` newtype
+
+#### Scenario: Money limiter extracts via its newtype
+
+- **WHEN** a handler writes `State(limiter): State<MoneyLimiter>`
+- **THEN** the extraction SHALL resolve to a clone of `state.money_limiter` wrapped in the `MoneyLimiter` newtype
+
+### Requirement: Portal handlers extract granular state, not AppState
+
+Every handler in `src/web/templates/`, `src/web/portal/`, and `src/web/portal/admin/` SHALL extract its dependencies via `State<Arc<dyn TargetService>>` (or analogous granular wrappers) rather than `State<AppState>`. The handler signature SHALL list exactly the services, repositories, and infrastructure components the body actually uses.
+
+Exceptions are allowed for handlers that genuinely use a broad cross-section (≥6 components, or otherwise unreasonable to enumerate). Such exceptions SHALL carry a brief comment explaining the choice. The default position is granular extraction.
+
+Middleware (functions wired via `from_fn_with_state`) SHALL continue to take `State<AppState>` — `FromRef` is for handler extraction, not for middleware.
+
+#### Scenario: New portal handler uses granular extraction
+
+- **WHEN** a contributor adds a new portal handler that uses a few specific services
+- **THEN** the handler SHALL extract those services individually via `State<Arc<…>>`; it SHALL NOT default to `State<AppState>` for convenience
+
+#### Scenario: Reader can see a handler's dependencies from its signature
+
+- **WHEN** a reader inspects a portal handler's signature
+- **THEN** the granular extractors SHALL enumerate exactly the dependencies the body uses; no domain navigation is needed to discover the actual surface
+
+#### Scenario: Exception is documented at the site
+
+- **WHEN** a contributor retains `State<AppState>` for a handler with broad cross-cutting needs
+- **THEN** a brief inline comment SHALL explain why (e.g., "Builds three integration events and reaches five services; granular extraction would yield 7 extractors")
+
+### Requirement: BaseContext takes granular inputs, not AppState
+
+The `BaseContext::for_member` helper SHALL take granular inputs (`csrf_service: &CsrfService`, `current_user: &CurrentUser`, `session: &SessionInfo`) rather than `&AppState`. This is so handlers that build a `BaseContext` for an Askama template can themselves use granular extraction without retaining `State<AppState>` solely to feed the helper.
+
+#### Scenario: Handler building BaseContext uses granular extraction
+
+- **WHEN** a portal handler renders an Askama page using `BaseContext::for_member(...)`
+- **THEN** the handler SHALL extract `State<Arc<CsrfService>>` granularly and pass `&csrf_service` to the helper; the handler SHALL NOT retain `State<AppState>` solely for the helper's sake
+
+### Requirement: API handlers extract granular state, not AppState
+
+Every handler in `src/api/handlers/` SHALL extract its dependencies via `State<Arc<dyn TargetService>>` (or analogous granular wrappers, including the `LoginLimiter` / `MoneyLimiter` newtypes for rate limiters) rather than `State<AppState>`. The handler signature SHALL list exactly the services, repositories, and infrastructure components the body uses.
+
+Exceptions are allowed for handlers with broad cross-cutting needs (≥6 extractors or otherwise unwieldy). Such exceptions SHALL carry a brief inline comment explaining why. The default position is granular extraction.
+
+Middleware in `src/api/middleware/` SHALL continue to use `State<AppState>` — `FromRef` is for handler extraction, not for middleware wired via `from_fn_with_state`.
+
+#### Scenario: API handler signature names its dependencies
+
+- **WHEN** a reader inspects any handler in `src/api/handlers/`
+- **THEN** the granular extractors SHALL enumerate exactly the dependencies the body uses; no domain navigation needed
+
+#### Scenario: Webhook handler exception is documented
+
+- **WHEN** `stripe_webhook` (or any other handler with genuine cross-cutting needs) retains `State<AppState>`
+- **THEN** a brief inline comment SHALL explain the choice; bare `State<AppState>` without justification SHALL be treated as a defect
+
+#### Scenario: Login limiter consumed via its newtype
+
+- **WHEN** the `login` handler extracts the rate limiter
+- **THEN** it SHALL extract `State<LoginLimiter>` (the newtype introduced by `add-fromref-impls-on-appstate`), not `State<RateLimiter>` (which doesn't exist as an unambiguous extractor)
+
+### Requirement: GET /setup redirects when an admin already exists
+
+The `/setup` GET handler SHALL check whether an admin already exists (via `check_admin_exists` or the `admin_exists_observed` `AppState` flag) and, if true, redirect to `/login` instead of rendering the setup form.
+
+This complements the existing POST /setup behavior (which already refuses post-bootstrap inside the `setup_lock` guard). After this change, /setup is fully a dead-end once bootstrap is complete: GET redirects away, POST refuses. The security exemption that lets /setup operate without a session is bounded strictly to the bootstrap window.
+
+#### Scenario: GET /setup after admin exists redirects to /login
+
+- **WHEN** a request hits `GET /setup` on an instance where at least one admin already exists
+- **THEN** the response SHALL be a 303 (or 302) redirect to `/login`; the setup form HTML SHALL NOT be rendered
+
+#### Scenario: GET /setup before admin exists renders the form
+
+- **WHEN** a request hits `GET /setup` on a fresh instance with no admin
+- **THEN** the response SHALL render the setup form HTML (preserving current first-boot behavior)
+
+#### Scenario: Reaches admin_exists_observed cache when populated
+
+- **WHEN** the GET /setup handler runs and `admin_exists_observed` is already `true` (set either by an earlier middleware check or by the wizard's create_admin call)
+- **THEN** the handler SHALL consult that cached value rather than re-querying the database, matching the optimization the `cache-has-admin-flag` change introduced for the middleware
+

--- a/openspec/specs/saved-card-management/spec.md
+++ b/openspec/specs/saved-card-management/spec.md
@@ -48,3 +48,21 @@ The full card number, CVV, and full expiry SHALL never be persisted.
 - **WHEN** a saved-card row is inspected
 - **THEN** it SHALL contain no PAN, no CVV, and only the metadata listed above
 
+### Requirement: Test fixtures representing valid saved cards use runtime-relative expiry dates
+
+Test fixtures (in particular `FakeStripeGateway`'s default `retrieve_payment_method` response) that represent "a valid, non-expired saved card" SHALL use a `exp_year` computed from `Utc::now().year()` at runtime, NOT a hardcoded future year literal.
+
+The reason: a hardcoded future year is a time-bomb — it represents a valid card today but becomes an expired card once wall-clock time reaches that year. Tests that implicitly depend on the default-fixture-card being valid will silently break. The same anti-pattern is addressed in the `admin-events` spec for materializer test anchors.
+
+Tests that deliberately exercise expired-card behavior MAY use hardcoded past or near-future expiry dates as inputs — the rule applies to fixtures representing "valid" cards, not to fixtures representing specific calendar boundary cases.
+
+#### Scenario: FakeStripeGateway default fixture is valid for years to come
+
+- **WHEN** a test calls `retrieve_payment_method` without queuing a specific response
+- **THEN** the returned `PaymentMethodDetails.exp_year` SHALL be at least `Utc::now().year() + 1` (i.e., never representing an expired card from the perspective of the running test)
+
+#### Scenario: Hardcoded future year in a "valid card" fixture is a defect
+
+- **WHEN** a contributor inspects a test fixture that represents "a valid saved card"
+- **THEN** a literal future year (e.g., `exp_year: 2030`) SHALL be treated as a defect to be replaced with a runtime-relative computation; the rule is "fixtures representing validity SHALL be valid regardless of when the test runs"
+

--- a/openspec/specs/scheduled-announcement-publish/spec.md
+++ b/openspec/specs/scheduled-announcement-publish/spec.md
@@ -1,0 +1,56 @@
+# scheduled-announcement-publish Specification
+
+## Purpose
+TBD - created by archiving change a11-scheduled-announcement-publish. Update Purpose after archive.
+## Requirements
+### Requirement: Announcements can carry a future publish time
+
+The `announcements` table SHALL include a nullable `scheduled_publish_at: Option<DateTime<Utc>>` column. A Draft announcement with `scheduled_publish_at` set is considered "scheduled." A Draft without it is just a Draft. A Published row's `scheduled_publish_at` is irrelevant (the runner clears it on transition).
+
+The new-announcement and edit-announcement admin forms SHALL accept an optional `scheduled_publish_at` input (HTML `datetime-local`). Empty input persists as `None`.
+
+#### Scenario: Admin creates a scheduled Draft
+
+- **WHEN** an admin submits the new-announcement form with a `scheduled_publish_at` value of "next Tuesday at 09:00 UTC"
+- **THEN** the announcement is created with `status = Draft` and `scheduled_publish_at = <that timestamp>`
+
+#### Scenario: Admin clears a schedule on edit
+
+- **WHEN** an admin edits a scheduled Draft and submits the form with an empty `scheduled_publish_at` input
+- **THEN** the announcement's `scheduled_publish_at` is set to `None`; the row stays Draft
+
+### Requirement: A background runner publishes scheduled announcements at their time
+
+`AnnouncementAdminService::publish_scheduled()` SHALL be called from `BillingRunner::run_cycle`. The method SHALL find all Draft announcements whose `scheduled_publish_at <= now` and, for each, atomically flip the row to Published, audit-log `auto_publish_announcement` with `actor_id = None`, and dispatch `IntegrationEvent::AnnouncementPublished(announcement)`.
+
+Precision is bounded by the runner tick interval (currently ~1 hour). A scheduled announcement fires in the first tick on or after its scheduled time.
+
+#### Scenario: Past-due Draft fires on the next tick
+
+- **WHEN** a Draft has `scheduled_publish_at = (now - 5 minutes)`
+- **THEN** the next runner tick SHALL flip it to Published, write an audit row, and dispatch `AnnouncementPublished`
+
+#### Scenario: Future Draft is not touched
+
+- **WHEN** a Draft has `scheduled_publish_at = (now + 2 hours)`
+- **THEN** the next runner tick (within the next hour) SHALL NOT touch it
+
+#### Scenario: Manual publish before scheduled time wins
+
+- **WHEN** an admin manually publishes a scheduled Draft via `/portal/admin/announcements/:id/publish` before its scheduled time arrives
+- **THEN** the row is Published with `actor_id = <admin>` on the audit row; when the scheduled time later arrives, the runner's atomic conditional UPDATE matches zero rows (status is already Published) and no second event is dispatched
+
+#### Scenario: System-initiated audit row has no actor
+
+- **WHEN** the runner auto-publishes a scheduled announcement
+- **THEN** the resulting `audit_logs` row SHALL have `actor_id = NULL` (matching the existing audit-log spec's "Option<UUID> — NULL for system-initiated entries")
+
+### Requirement: The Draft→Published transition is atomic
+
+The repository method that the runner uses SHALL execute a conditional UPDATE that flips status only when the row is still Draft. Two concurrent runner ticks (e.g., across a server restart that overlaps with the next tick) SHALL NOT both dispatch the integration event.
+
+#### Scenario: Conditional update prevents double-dispatch
+
+- **WHEN** two concurrent calls to `mark_published_now(id)` run against the same Draft row
+- **THEN** exactly one SHALL return true (the winner does the audit + dispatch); the other SHALL return false (and skip the dispatch)
+

--- a/openspec/specs/shared-utilities/spec.md
+++ b/openspec/specs/shared-utilities/spec.md
@@ -1,0 +1,52 @@
+# shared-utilities Specification
+
+## Purpose
+TBD - created by archiving change a30-extract-small-duplications. Update Purpose after archive.
+## Requirements
+### Requirement: capitalize_first is defined once
+
+`fn capitalize_first(s: &str) -> String` SHALL exist exactly once in the codebase, at `src/util/string.rs`, with visibility `pub`. The duplicate copies at `src/repository/basic_type_repository.rs`, `src/web/portal/admin/types.rs`, and `src/service/basic_type_service.rs` SHALL be removed; each call site SHALL import via `use crate::util::string::capitalize_first;`.
+
+#### Scenario: grep finds exactly one definition
+
+- **WHEN** `grep -rn "fn capitalize_first" src/` is run after this change
+- **THEN** exactly one match SHALL appear, at `src/util/string.rs`
+
+### Requirement: generate_token and hash_token are defined once each
+
+The 32-byte-hex random token generator `fn generate_token() -> String` SHALL be defined exactly once at `src/auth/tokens.rs` with visibility `pub`. The SHA256-hex hasher `fn hash_token(token: &str) -> String` SHALL also be defined exactly once in the same module.
+
+The duplicate copies in `src/auth/pending_login.rs`, `src/auth/mod.rs` (for `generate_token`), `src/auth/email_tokens.rs`, and `src/auth/session.rs` (for `hash_token`) SHALL be removed. Each call site SHALL import via `use crate::auth::tokens::{generate_token, hash_token};` (or whichever subset it needs).
+
+The unrelated `pub async fn generate_token(&self, session_id: &str)` on the CSRF type at `src/auth/csrf.rs` is NOT a duplicate (different signature on a different type) and SHALL be left in place unchanged.
+
+#### Scenario: grep finds exactly one free-function definition of each
+
+- **WHEN** `grep -rn "^fn generate_token" src/ "    fn generate_token" src/` is run (catching both top-level and method definitions excluding the CSRF method via its `pub async` keyword)
+- **THEN** exactly one free-function definition SHALL exist at `src/auth/tokens.rs`
+- **WHEN** the same check is done for `fn hash_token`
+- **THEN** exactly one definition SHALL exist at `src/auth/tokens.rs`
+
+### Requirement: test_result_html is defined once with an id parameter
+
+`fn test_result_html(id: &str, ok: bool, detail: &str) -> axum::response::Html<String>` SHALL be defined exactly once at `src/web/portal/admin/test_result.rs` with visibility `pub`. The duplicate copies at `src/web/portal/admin/email.rs` and `src/web/portal/admin/discord.rs` SHALL be removed. Call sites SHALL be updated to pass the id they need (`"test-result"` for email, `"discord-test-result"` for discord).
+
+#### Scenario: Both admin pages render the same HTML shape as before
+
+- **WHEN** the email-test action and the discord-test action are exercised after this change
+- **THEN** each SHALL produce HTML byte-for-byte identical to the pre-change output (same div ids, same class lists, same SVG markup)
+
+### Requirement: parse_member_status remains intentionally duplicated
+
+The two `parse_member_status` implementations SHALL be left as separate functions:
+
+- `MemberRepository::parse_member_status` returns `Result<MemberStatus>` and errors on invalid input (runtime use).
+- `bin/seed::parse_member_status` returns `MemberStatus` and defaults to `Pending` on invalid input (permissive use for seed fixtures).
+
+A one-line comment SHALL be added to the seed copy noting that the permissive behavior is intentional and pointing at the strict version for runtime parsing.
+
+#### Scenario: Seed binary's parse_member_status keeps its fallback
+
+- **WHEN** the seed binary encounters an unknown status string after this change
+- **THEN** it SHALL still produce `MemberStatus::Pending` (NOT error), and a comment in the source SHALL document this behavior
+

--- a/openspec/specs/stripe-test-then-live/spec.md
+++ b/openspec/specs/stripe-test-then-live/spec.md
@@ -1,0 +1,101 @@
+# stripe-test-then-live Specification
+
+## Purpose
+TBD - created by archiving change a25-stripe-test-mode-and-switchover. Update Purpose after archive.
+## Requirements
+### Requirement: Test mode uses a separate database file
+
+When the wizard's "test mode or live mode?" prompt is answered "test," the resulting Coterie instance SHALL be configured with `DATABASE_URL` pointing at `sqlite:///var/lib/coterie/coterie-test.db?mode=rwc` (instead of `coterie.db`). Test charges, test members, test audit rows, and any other state generated during the verification phase SHALL live in this file.
+
+The live database file `coterie.db` SHALL NOT exist or be touched during test-mode operation. It is created fresh by the switchover subcommand.
+
+#### Scenario: Wizard in test mode creates coterie-test.db
+
+- **WHEN** the wizard runs with test mode selected
+- **THEN** `/var/lib/coterie/coterie-test.db` SHALL be created with migrations applied; `/var/lib/coterie/coterie.db` SHALL NOT exist; `.env`'s `COTERIE__DATABASE__URL` SHALL reference `coterie-test.db`
+
+#### Scenario: Test data is fully isolated
+
+- **WHEN** test charges are made during test-mode operation
+- **THEN** the resulting member rows, payment rows, audit log entries SHALL be in `coterie-test.db`; the live database is unaffected (because it doesn't exist yet)
+
+### Requirement: coterie-provision switch-stripe-to-live transitions from test to live mode atomically
+
+The `coterie-provision` Rust binary (introduced by `a24`) SHALL gain a `switch-stripe-to-live` subcommand that handles the one-shot transition from test mode to live mode. The subcommand SHALL:
+
+1. Refuse if `.env` already shows `pk_live_*` credentials.
+2. Refuse if `/var/lib/coterie/coterie-test.db` doesn't exist.
+3. Load live Stripe credentials from `/opt/coterie/.env.live` if present; otherwise prompt for them (interactively or via `--no-prompt` env-var pathway).
+4. Validate credentials are well-formed (`pk_live_*`, `sk_live_*`, `whsec_*`) via the existing `validate_prefix` helper.
+5. Validate the secret key by calling `https://api.stripe.com/v1/balance` (via the `StripeApi` trait) with it as basic auth. Abort BEFORE any destructive operation if the API rejects.
+6. Stop the `coterie` service via the `SystemCommand` trait.
+7. Create a fresh `/var/lib/coterie/coterie.db` and ensure migrations are applied.
+8. Copy the admin row(s) from `coterie-test.db` to `coterie.db` via `ATTACH DATABASE ... INSERT SELECT`.
+9. Archive `coterie-test.db` to `coterie-test-archive-YYYYMMDD-HHMMSS.db` (or delete if `--discard-test-db` was passed).
+10. Atomically rewrite `.env` with live credentials and the new `DATABASE_URL` (write to `.env.new`, rename to `.env`).
+11. Remove `/opt/coterie/.env.live` if it existed.
+12. Start the `coterie` service.
+13. Smoke-test `GET http://127.0.0.1:8080/health` returns 200.
+14. Print a reminder about registering the live-mode webhook in Stripe's dashboard.
+
+All side-effecting operations SHALL go through the `SystemCommand`, `FileSystem`, and `StripeApi` traits so the subcommand is fully testable via `cargo test` with fake implementations.
+
+#### Scenario: Successful test-to-live switchover
+
+- **WHEN** an operator runs `coterie-provision switch-stripe-to-live` on an instance currently in test mode
+- **THEN** after completion: `.env` contains live credentials; `DATABASE_URL` references `coterie.db`; `coterie.db` exists with the admin row preserved; `coterie-test.db` is renamed to an archive name; `.env.live` (if it existed) is removed; the service is running and reachable; the operator's existing admin password works for login
+
+#### Scenario: Refuse to switch when already in live mode
+
+- **WHEN** `coterie-provision switch-stripe-to-live` is invoked on an instance whose `.env` already has `pk_live_*`
+- **THEN** the subcommand SHALL exit non-zero with a clear message; no modifications SHALL occur
+
+#### Scenario: Refuse to switch when no test DB exists
+
+- **WHEN** `coterie-provision switch-stripe-to-live` is invoked on an instance that doesn't have a `coterie-test.db` file
+- **THEN** the subcommand SHALL exit non-zero ("instance is not in test mode; nothing to switch from"); no modifications
+
+#### Scenario: Stripe API rejects the live secret key
+
+- **WHEN** the supplied live secret key fails the `/v1/balance` validation (as determined by the `StripeApi` trait — `FakeStripeApi` in tests, `RealStripeApi` in prod)
+- **THEN** the subcommand SHALL abort BEFORE stopping the service or modifying `.env`; the test-mode instance SHALL remain running
+
+#### Scenario: Integration test covers the happy path via fakes
+
+- **WHEN** the autocoder runs `cargo test -p coterie-provision`
+- **THEN** an integration test SHALL exercise `switch-stripe-to-live` end-to-end against `FakeSystem`, `FakeFs`, and `FakeStripeApi`, asserting on the expected command sequence, the .env contents (via golden snapshot), and the archive/removal of test artifacts
+
+### Requirement: Admin row migrates across the DB swap
+
+The switchover subcommand SHALL preserve the operator's admin row(s) from `coterie-test.db` into the new `coterie.db` using SQLite's `ATTACH DATABASE` mechanism. The hashed password, email, username, and `is_admin` flag SHALL all migrate verbatim. The operator's existing credentials SHALL work for login against the new live database without re-entering the password.
+
+#### Scenario: Admin login works after switchover
+
+- **WHEN** an operator logs in via `/login` immediately after the switchover completes
+- **THEN** the credentials they used during test-mode operation SHALL authenticate successfully against the new live database
+
+#### Scenario: Multiple admins migrate together
+
+- **WHEN** the test database has multiple admin rows (e.g., the operator added a second admin via the UI during testing)
+- **THEN** all rows with `is_admin = 1` SHALL be copied to the live database; the subcommand SHALL NOT silently drop any
+
+### Requirement: Live credentials may be pre-loaded at wizard time
+
+The wizard MAY optionally collect live Stripe credentials at the same time it collects test credentials, storing them in `/opt/coterie/.env.live` (chmod 0640, owned by `coterie`). The switchover subcommand SHALL detect this file and use its contents instead of prompting. This is convenience-only — operators without live credentials at wizard time can defer; the switchover prompts at run time.
+
+After consumption, the switchover SHALL remove `.env.live` so live credentials don't linger in two files on disk.
+
+#### Scenario: Wizard stashes live creds, switchover uses them without prompting
+
+- **WHEN** the wizard runs in test mode and the operator supplies both test AND live credentials
+- **THEN** test creds go into `.env`; live creds go into `/opt/coterie/.env.live` with mode 0640
+- **WHEN** the operator later runs the switchover
+- **THEN** the subcommand SHALL read live creds from `.env.live`, skip the credential prompts, and remove `.env.live` after the .env rewrite completes
+
+#### Scenario: Wizard skips live creds, switchover prompts later
+
+- **WHEN** the wizard runs in test mode and the operator chooses not to supply live credentials
+- **THEN** no `.env.live` file is created
+- **WHEN** the operator later runs the switchover
+- **THEN** the subcommand SHALL prompt for each live credential at run time (or accept them via env/flag in non-interactive mode)
+

--- a/openspec/specs/stripe-webhook/spec.md
+++ b/openspec/specs/stripe-webhook/spec.md
@@ -73,3 +73,39 @@ Side-effects (audit-log entries, integration events, dues-paid-until updates) fo
 - **WHEN** a payment is recorded via the webhook AND an equivalent payment is recorded by an admin
 - **THEN** the audit-log rows and integration events SHALL describe the same business action with the same target/payload shape (differing only in actor and source fields)
 
+### Requirement: Invoice-event webhook handlers have integration test coverage
+
+`tests/stripe_webhook_test.rs` SHALL include test coverage for both `handle_invoice_paid` and `handle_invoice_payment_failed`. The tests SHALL exercise:
+
+- The happy path (event matches a known member, expected DB state change occurs).
+- Idempotency (same event fired twice produces single DB state change).
+- Graceful handling of events for subscriptions Coterie doesn't know about (no panic, no spurious DB writes).
+- For `handle_invoice_payment_failed`: the `AdminAlert` dispatch is verified — this is the production lifeline for operators to learn about billing failures without polling logs.
+
+Adding handler changes for these event types in the future SHALL include updates to the relevant test, not just a "trust me" commit.
+
+#### Scenario: invoice.paid extends dues for known subscription
+
+- **WHEN** an `invoice.paid` event is dispatched for a subscription ID that matches an active `StripeSubscription`-mode member
+- **THEN** the test SHALL assert that the member's `dues_paid_until` advances by the membership billing period AND a Payment row is recorded with the event's payment_intent ID
+
+#### Scenario: invoice.paid is idempotent under Stripe retry
+
+- **WHEN** the same `invoice.paid` event is dispatched twice (simulating Stripe's at-least-once delivery semantics)
+- **THEN** the test SHALL assert that `dues_paid_until` advances exactly once, not twice
+
+#### Scenario: invoice.payment_failed dispatches AdminAlert
+
+- **WHEN** an `invoice.payment_failed` event is dispatched for a known `StripeSubscription`-mode member
+- **THEN** the test SHALL assert that `IntegrationEvent::AdminAlert` was dispatched to the IntegrationManager (verifiable via test harness recording the dispatched events)
+
+#### Scenario: invoice.payment_failed final-attempt passes is_final=true
+
+- **WHEN** an `invoice.payment_failed` event has `next_payment_attempt = None` (Stripe exhausted retries)
+- **THEN** the test SHALL assert that `Notifications::notify_subscription_payment_failed` was called with `is_final = true`
+
+#### Scenario: Invoice events for unknown subscription_id are noops
+
+- **WHEN** an `invoice.paid` or `invoice.payment_failed` event references a subscription ID that doesn't map to any known member
+- **THEN** the test SHALL assert no DB state change AND no panic AND no AdminAlert dispatch
+

--- a/openspec/specs/test-infrastructure/spec.md
+++ b/openspec/specs/test-infrastructure/spec.md
@@ -1,0 +1,35 @@
+# test-infrastructure Specification
+
+## Purpose
+TBD - created by archiving change a26-consolidate-test-helpers. Update Purpose after archive.
+## Requirements
+### Requirement: Shared test helpers live in tests/common/mod.rs
+
+Integration-test scaffolding functions duplicated across multiple test files SHALL be consolidated into `tests/common/mod.rs`. The following helpers (identified by the architecture pass) SHALL have exactly one canonical implementation in `tests/common/mod.rs`, with all other copies removed:
+
+- `fresh_pool()` — currently duplicated across 18 test files
+- `build_app_state(pool: SqlitePool)` — 3 files
+- `build_harness()` — 6 files
+- `make_member(pool: &SqlitePool, ...)` — 3 files
+- `build()` — 2 files (only if the implementations agree)
+- Other helpers duplicated ≥3 times that surface during the consolidation
+
+Test files using these helpers SHALL include them via `mod common;` and `use common::*;` (or specific items) in place of local definitions.
+
+The shared module SHALL NOT contain helpers that are genuinely test-specific or depend on `#[cfg(feature = "test-utils")]`-gated production-side code that conflicts with unconditional compilation.
+
+#### Scenario: fresh_pool has exactly one definition
+
+- **WHEN** the codebase is grepped for `fn fresh_pool` after this change
+- **THEN** exactly one definition SHALL exist, and it SHALL live in `tests/common/mod.rs`
+
+#### Scenario: All previously-passing tests still pass
+
+- **WHEN** `cargo test --features test-utils` is run after consolidation
+- **THEN** every test that passed before SHALL still pass; no tests are lost or added by this refactor
+
+#### Scenario: Behaviorally-different copies are preserved as separately-named variants
+
+- **WHEN** two copies of a helper turn out to differ in behaviorally meaningful ways (different seed data, different pool options, different return shape)
+- **THEN** the consolidation SHALL preserve both as separately-named functions in `tests/common/mod.rs` (e.g., `fresh_pool()` and `fresh_pool_with_seed()`), NOT silently pick one and discard the other
+

--- a/openspec/specs/webhook-dispatcher-layout/spec.md
+++ b/openspec/specs/webhook-dispatcher-layout/spec.md
@@ -1,0 +1,38 @@
+# webhook-dispatcher-layout Specification
+
+## Purpose
+TBD - created by archiving change a29-split-webhook-dispatcher. Update Purpose after archive.
+## Requirements
+### Requirement: WebhookDispatcher is organized into per-event-family submodules
+
+`src/payments/webhook_dispatcher.rs` SHALL be converted to a module directory at `src/payments/webhook_dispatcher/` with the following submodules:
+
+- `mod.rs` — `WebhookDispatcher` struct, `new()`, `handle_webhook` (the event-type router), and the `dispatch_*` test seams (currently in the second `impl` block)
+- `payment_intent.rs` — `handle_payment_intent_succeeded`, `handle_failed_payment`, `handle_successful_payment`
+- `charge.rs` — `handle_charge_refunded`
+- `checkout.rs` — `handle_expired_session`
+- `invoice.rs` — `handle_invoice_paid`, `handle_invoice_payment_failed`
+- `subscription.rs` — `handle_subscription_deleted`, `handle_subscription_updated`
+
+All handler methods SHALL remain in `impl WebhookDispatcher` blocks (multiple `impl` blocks for the same type are valid Rust). Per-event handlers SHALL have visibility `pub(super)` so the router in `mod.rs` can call them.
+
+#### Scenario: No submodule exceeds 300 lines
+
+- **WHEN** the post-split files in `src/payments/webhook_dispatcher/` are line-counted
+- **THEN** every file SHALL be ≤300 lines
+
+#### Scenario: All webhook tests still pass
+
+- **WHEN** `cargo test --features test-utils -- stripe_webhook` is run after the split
+- **THEN** every test in `tests/stripe_webhook_test.rs` SHALL still pass with the same assertions; no test logic needs to change
+
+#### Scenario: The dispatch_* test seams remain in mod.rs
+
+- **WHEN** the `dispatch_payment_intent_succeeded`, `dispatch_charge_refunded`, `dispatch_subscription_deleted`, `dispatch_checkout_session_completed`, `dispatch_invoice_paid`, `dispatch_invoice_payment_failed` functions are located after the split
+- **THEN** they SHALL live in `mod.rs` (or a single `test_seams.rs` submodule if `mod.rs` becomes too large), NOT scattered across the per-event submodules
+
+#### Scenario: External callers compile unchanged
+
+- **WHEN** code outside `src/payments/webhook_dispatcher/` that calls `WebhookDispatcher::new()` or `WebhookDispatcher::handle_webhook(...)` is built after the split
+- **THEN** it SHALL compile without modification
+


### PR DESCRIPTION
This PR was generated by `autocoder sync-specs --rebuild`.

Replayed 41 archived change(s) chronologically; 34 succeeded, 7 failed.

**Failed changes** (left at active path for operator inspection):
- `a03-narrow-saved-card-json-surface`: openspec archive exited 0 but post-condition failed: active path still present at /tmp/workspaces/github_com_IndustriousKraken_coterie/openspec/changes/a03-narrow-saved-card-json-surface; openspec out…
- `lift-member-admin-orchestration`: openspec archive exited 0 but post-condition failed: active path still present at /tmp/workspaces/github_com_IndustriousKraken_coterie/openspec/changes/lift-member-admin-orchestration; openspec output…
- `a08-lift-event-admin-orchestration`: openspec archive exited 0 but post-condition failed: active path still present at /tmp/workspaces/github_com_IndustriousKraken_coterie/openspec/changes/a08-lift-event-admin-orchestration; openspec out…
- `a09-lift-announcement-admin-orchestration`: openspec archive exited 0 but post-condition failed: active path still present at /tmp/workspaces/github_com_IndustriousKraken_coterie/openspec/changes/a09-lift-announcement-admin-orchestration; opens…
- `a17-normalize-email-token-service`: openspec archive exited 0 but post-condition failed: active path still present at /tmp/workspaces/github_com_IndustriousKraken_coterie/openspec/changes/a17-normalize-email-token-service; openspec outp…
- `a20-import-billing-fields`: openspec archive exited 0 but post-condition failed: active path still present at /tmp/workspaces/github_com_IndustriousKraken_coterie/openspec/changes/a20-import-billing-fields; openspec output: open…
- `a22-alert-on-coterie-managed-charge-failures`: openspec archive exited 0 but post-condition failed: active path still present at /tmp/workspaces/github_com_IndustriousKraken_coterie/openspec/changes/a22-alert-on-coterie-managed-charge-failures; op…

**Canonical spec files**:
- `openspec/specs/admin-alert-email/spec.md` (unchanged)
- `openspec/specs/admin-announcements/spec.md` (modified)
- `openspec/specs/admin-audit-log/spec.md` (unchanged)
- `openspec/specs/admin-billing-dashboard/spec.md` (unchanged)
- `openspec/specs/admin-events/spec.md` (modified)
- `openspec/specs/admin-integrations/spec.md` (unchanged)
- `openspec/specs/admin-members-handlers-layout/spec.md` (modified)
- `openspec/specs/admin-members/spec.md` (modified)
- `openspec/specs/admin-payments/spec.md` (modified)
- `openspec/specs/admin-settings/spec.md` (unchanged)
- `openspec/specs/admin-types/spec.md` (modified)
- `openspec/specs/audit-logging/spec.md` (modified)
- `openspec/specs/auth-middleware-tiers/spec.md` (modified)
- `openspec/specs/bootstrap-admin-cli/spec.md` (modified)
- `openspec/specs/bot-challenge/spec.md` (unchanged)
- `openspec/specs/bulk-member-csv-export/spec.md` (modified)
- `openspec/specs/bulk-member-csv-import/spec.md` (modified)
- `openspec/specs/cors-policy/spec.md` (unchanged)
- `openspec/specs/csrf-protection/spec.md` (unchanged)
- `openspec/specs/discord-integration/spec.md` (unchanged)
- `openspec/specs/domain-types/spec.md` (modified)
- `openspec/specs/dues-restoration/spec.md` (unchanged)
- `openspec/specs/email-tokens/spec.md` (modified)
- `openspec/specs/event-reminders/spec.md` (modified)
- `openspec/specs/integration-events/spec.md` (modified)
- `openspec/specs/member-content/spec.md` (unchanged)
- `openspec/specs/member-dashboard/spec.md` (unchanged)
- `openspec/specs/member-donations/spec.md` (unchanged)
- `openspec/specs/member-profile/spec.md` (unchanged)
- `openspec/specs/member-saved-cards/spec.md` (unchanged)
- `openspec/specs/member-service-layout/spec.md` (modified)
- `openspec/specs/password-management/spec.md` (unchanged)
- `openspec/specs/payment-admin-service/spec.md` (modified)
- `openspec/specs/payment-recording/spec.md` (modified)
- `openspec/specs/portal-payments-handlers-layout/spec.md` (modified)
- `openspec/specs/provisioning-wizard/spec.md` (modified)
- `openspec/specs/public-content-feeds/spec.md` (unchanged)
- `openspec/specs/public-donate/spec.md` (unchanged)
- `openspec/specs/public-signup/spec.md` (unchanged)
- `openspec/specs/rate-limiting/spec.md` (unchanged)
- `openspec/specs/recovery-codes/spec.md` (unchanged)
- `openspec/specs/recurring-billing/spec.md` (modified)
- `openspec/specs/repository-contracts/spec.md` (modified)
- `openspec/specs/routing-architecture/spec.md` (modified)
- `openspec/specs/saved-card-management/spec.md` (modified)
- `openspec/specs/scheduled-announcement-publish/spec.md` (modified)
- `openspec/specs/scheduled-payments/spec.md` (unchanged)
- `openspec/specs/security-headers/spec.md` (unchanged)
- `openspec/specs/session-auth/spec.md` (unchanged)
- `openspec/specs/shared-utilities/spec.md` (modified)
- `openspec/specs/stripe-test-then-live/spec.md` (modified)
- `openspec/specs/stripe-webhook/spec.md` (modified)
- `openspec/specs/test-infrastructure/spec.md` (modified)
- `openspec/specs/totp-2fa/spec.md` (unchanged)
- `openspec/specs/unifi-integration/spec.md` (unchanged)
- `openspec/specs/webhook-dispatcher-layout/spec.md` (modified)
