### PR TITLE
audit-only: 1 proposal(s) from security-bug

### DIFF
--- a/openspec/changes/fix-unicode-unsafe-truncation-panics-in-admin-views/.openspec.yaml
+++ b/openspec/changes/fix-unicode-unsafe-truncation-panics-in-admin-views/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-12

--- a/openspec/changes/fix-unicode-unsafe-truncation-panics-in-admin-views/proposal.md
+++ b/openspec/changes/fix-unicode-unsafe-truncation-panics-in-admin-views/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+Two admin-facing render paths truncate free-text with **byte-indexed slicing**, which panics when the cut byte lands in the middle of a multi-byte UTF-8 character. The codebase already documents this exact bug class and a safe workaround at `src/integrations/discord.rs:49` ("The naive `&s[..280]` would panic on content with a multi-byte UTF-8 character crossing the boundary") — these two sites simply never applied that safe pattern.
+
+1. **`src/web/portal/admin/audit.rs:144`** — `truncate(s)` does:
+   ```rust
+   fn truncate(s: &str) -> &str {
+       const MAX: usize = 120;
+       if s.len() <= MAX { s } else { &s[..MAX] }   // byte slice, not char-safe
+   }
+   ```
+   It is called from `format_detail` (`audit.rs:131,133,134`) on the audit row's `old_value` / `new_value` columns, which carry admin- and member-entered free text: membership-type / basic-type names (`src/web/portal/admin/types.rs:290,572`), expense category/account names (`src/service/expense_category_service.rs:56`, `src/service/expense_account_service.rs:54`), announcement and event titles (`src/service/announcement_admin_service.rs:125`, `src/service/event_admin_service.rs:159`), settings values such as the org name/description (`src/web/portal/admin/settings.rs:173-174`), member emails (`src/service/member_service/create.rs:43`), and payment descriptions (`src/service/payment_service.rs:183-186`). None of these fields are restricted to ASCII or bounded in length.
+
+   **Trigger:** persist any such value longer than 120 bytes containing a multi-byte character (emoji, accented letter, CJK script) that straddles byte index 120 — something that happens in *ordinary* use, e.g. an org name or announcement title with an emoji, not just a malicious payload. `truncate` is reached by both `GET /portal/admin/audit` (`audit_log_page` → `filtered_entries`, `audit.rs:120`) and `GET /portal/admin/audit/export` (which reuses `truncate` via the same display mapping).
+
+   **Harm:** the slice panics, aborting the request-handling task. There is no `CatchPanicLayer` in the router, so the connection is reset with no HTTP response (effective 500). A single poisoned row makes the audit-log viewer **and** its CSV export un-loadable for **every** admin — a persistent partial denial of service against a security/compliance control — until the offending row is removed directly from the database.
+
+2. **`src/web/portal/admin/announcements.rs:231`** — the admin announcements list builds a preview with:
+   ```rust
+   let content_preview = if a.content.len() > 100 {
+       format!("{}...", &a.content[..100])   // byte slice on announcement body
+   } else { a.content.clone() };
+   ```
+   **Trigger:** an announcement whose body exceeds 100 bytes with a multi-byte character crossing byte index 100. **Harm:** loading `GET /portal/admin/announcements` (`admin_announcements_page`) panics, making the announcements admin list page unreachable while such an announcement exists.
+
+Both are the same root cause (byte-indexed truncation of UTF-8 text) and share one fix. The attacker is at minimum any account that can persist a multi-byte free-text value into one of these fields (admin/staff today); for the audit log the impact is amplified because one record disables the page for all admins. The bug is also reachable by accident through normal non-ASCII content.
+
+## What Changes
+
+- **Add a shared, char-boundary-safe truncate helper** to `src/util/string.rs`:
+  ```rust
+  /// Truncate `s` to at most `max_chars` characters on a UTF-8 char
+  /// boundary, returning a borrowed sub-slice (no allocation). Unlike
+  /// `&s[..n]`, this never panics on multi-byte content.
+  pub fn truncate_chars(s: &str, max_chars: usize) -> &str {
+      match s.char_indices().nth(max_chars) {
+          Some((idx, _)) => &s[..idx],
+          None => s,
+      }
+  }
+  ```
+- **`src/web/portal/admin/audit.rs`** — reimplement `truncate` in terms of `truncate_chars(s, 120)` (or replace its body with the char-boundary match), eliminating the `&s[..MAX]` slice. Behavior is unchanged for ASCII input.
+- **`src/web/portal/admin/announcements.rs`** — replace `&a.content[..100]` with `truncate_chars(&a.content, 100)`, appending the `...` ellipsis only when truncation actually occurred (i.e. the returned slice is shorter than the source).
+- **Spec updates.** Add a robustness invariant to the `admin-audit-log` capability (the audit viewer and export SHALL NOT panic on multi-byte free-text values) and to the `admin-announcements` capability (the announcements list SHALL NOT panic on multi-byte announcement bodies).
+- **Tests.** Unit-test `truncate_chars` on a string whose byte-`max` boundary splits a multi-byte character; regression-test that `truncate`/the announcement preview return a valid (non-panicking) value for such input.
+
+## Capabilities
+
+### New Capabilities
+None.
+
+### Modified Capabilities
+- `admin-audit-log` — adds an invariant that the audit-log viewer and CSV export render multi-byte free-text values without panicking.
+- `admin-announcements` — adds an invariant that the admin announcements list renders multi-byte bodies without panicking.
+
+## Impact
+
+- **Code**: ~10 added lines in `src/util/string.rs` (new helper + test); ~3 changed lines in `src/web/portal/admin/audit.rs`; ~3 changed lines in `src/web/portal/admin/announcements.rs`.
+- **Wire shape**: no route, request, or response-shape changes. The only observable difference is that previously-panicking requests now return a normal truncated preview.
+- **Risk**: low. The change only alters behavior on multi-byte boundary inputs that currently crash; ASCII inputs are byte-for-byte identical to today.
+- **Operator follow-up**: if a poisoned `audit_logs` row already exists in a deployed database, the audit page will keep failing until this fix is deployed; after deploy no manual cleanup is required (the row renders safely). The other free-text byte-slice sites that are already safe — `short_id` at `audit.rs:259` (guarded by `len() > 8`, entity_id is always a UUID/`*`) and `&member_id.to_string()[..8]` at `src/web/portal/admin/billing.rs:343` (UUIDs are ASCII) — are intentionally left unchanged.

--- a/openspec/changes/fix-unicode-unsafe-truncation-panics-in-admin-views/specs/admin-announcements/spec.md
+++ b/openspec/changes/fix-unicode-unsafe-truncation-panics-in-admin-views/specs/admin-announcements/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Announcement list preview tolerates multi-byte bodies
+
+The admin announcements list (`GET /portal/admin/announcements`) SHALL build each row's content preview without panicking, regardless of the announcement body's length or UTF-8 content. The preview truncation SHALL cut on a UTF-8 character boundary, never on a raw byte index.
+
+#### Scenario: Announcement body with a multi-byte character at the truncation boundary renders safely
+
+- **GIVEN** an announcement whose body is longer than the preview limit and contains a multi-byte UTF-8 character (e.g. an emoji) straddling the limit
+- **WHEN** an admin loads `GET /portal/admin/announcements`
+- **THEN** the request SHALL complete without panicking and the preview SHALL be truncated on a character boundary with an ellipsis appended
+
+#### Scenario: Short ASCII bodies are shown in full
+
+- **WHEN** an announcement body is plain ASCII at or below the preview limit
+- **THEN** the preview SHALL equal the full body with no ellipsis appended

--- a/openspec/changes/fix-unicode-unsafe-truncation-panics-in-admin-views/specs/admin-audit-log/spec.md
+++ b/openspec/changes/fix-unicode-unsafe-truncation-panics-in-admin-views/specs/admin-audit-log/spec.md
@@ -1,0 +1,16 @@
+## ADDED Requirements
+
+### Requirement: Audit-log rendering tolerates multi-byte free-text values
+
+The audit-log viewer (`GET /portal/admin/audit`) and CSV export (`GET /portal/admin/audit/export`) SHALL render the member- and admin-influenced free-text columns (`old_value`, `new_value`) without panicking, regardless of the values' length or UTF-8 content. Any truncation applied for display SHALL cut on a UTF-8 character boundary, never on a raw byte index, so that a multi-byte character spanning the truncation point cannot cause a panic.
+
+#### Scenario: Audit value with a multi-byte character at the truncation boundary renders safely
+
+- **GIVEN** an `audit_logs` row whose `new_value` is longer than the display truncation limit and contains a multi-byte UTF-8 character (e.g. an emoji or accented letter) straddling the limit
+- **WHEN** an admin loads `GET /portal/admin/audit` or `GET /portal/admin/audit/export`
+- **THEN** the request SHALL complete without panicking and the displayed/exported detail SHALL be truncated on a character boundary (no partial multi-byte sequence)
+
+#### Scenario: ASCII audit values are unaffected
+
+- **WHEN** an `audit_logs` row's `new_value` is plain ASCII at or below the truncation limit
+- **THEN** the rendered detail SHALL be byte-for-byte identical to the stored value

--- a/openspec/changes/fix-unicode-unsafe-truncation-panics-in-admin-views/tasks.md
+++ b/openspec/changes/fix-unicode-unsafe-truncation-panics-in-admin-views/tasks.md
@@ -1,0 +1,44 @@
+## 1. Add a char-boundary-safe truncate helper
+
+- [ ] 1.1 In `src/util/string.rs`, add a public function:
+  ```rust
+  /// Truncate `s` to at most `max_chars` characters on a UTF-8 char
+  /// boundary, returning a borrowed sub-slice (no allocation). Unlike
+  /// `&s[..n]`, this never panics on multi-byte content.
+  pub fn truncate_chars(s: &str, max_chars: usize) -> &str {
+      match s.char_indices().nth(max_chars) {
+          Some((idx, _)) => &s[..idx],
+          None => s,
+      }
+  }
+  ```
+- [ ] 1.2 Add a unit test in `src/util/string.rs` named `truncate_chars_does_not_split_multibyte` asserting that `truncate_chars("é".repeat(200).as_str(), 120)` returns a valid `&str` (no panic) whose `chars().count()` is `120`, and that `truncate_chars("ascii", 100)` returns `"ascii"` unchanged.
+
+## 2. Fix the audit-log truncate panic
+
+- [ ] 2.1 In `src/web/portal/admin/audit.rs`, replace the body of `fn truncate(s: &str) -> &str` (currently `if s.len() <= MAX { s } else { &s[..MAX] }`, lines ~139-146) so it no longer slices by byte index. Either call the new helper:
+  ```rust
+  fn truncate(s: &str) -> &str {
+      crate::util::string::truncate_chars(s, 120)
+  }
+  ```
+  or inline the equivalent `char_indices().nth(120)` match. Keep the `&str` return type so `format_detail` is unaffected.
+- [ ] 2.2 Add a regression test (in `src/web/portal/admin/audit.rs` tests, or `tests/`) named `audit_truncate_handles_multibyte_boundary` that calls `truncate` (or `format_detail` with a `new` value of `"é".repeat(200)`) and asserts it returns without panicking.
+
+## 3. Fix the announcements preview panic
+
+- [ ] 3.1 In `src/web/portal/admin/announcements.rs` (the `content_preview` block around lines 230-234), replace `&a.content[..100]` with the char-safe helper. Append the `...` ellipsis only when truncation actually happened:
+  ```rust
+  let preview = crate::util::string::truncate_chars(&a.content, 100);
+  let content_preview = if preview.len() < a.content.len() {
+      format!("{}...", preview)
+  } else {
+      a.content.clone()
+  };
+  ```
+- [ ] 3.2 Confirm no remaining `&a.content[..` byte-index slice exists in the function after the edit.
+
+## 4. Verify
+
+- [ ] 4.1 Run `cargo test` for the new `truncate_chars` test and the two regression tests; confirm they pass.
+- [ ] 4.2 Grep `src/web/portal/admin/` for `[..` byte-slice patterns on free-text values and confirm only the known-safe sites remain (`audit.rs` `short_id` guarded by `len() > 8`; `billing.rs:343` on a UUID string).


### PR DESCRIPTION
This PR ships audit-produced proposals only — no implementer changes this iteration.

## Audit-produced proposals

- audit: security-bug proposals (1 change(s))

Each `audit: <type>` commit creates new `openspec/changes/<prefix>-*` directories that the next polling iteration will pick up via `list_pending` and route to the implementer.
