### PR TITLE
audit-only: 3 proposal(s) from security-bug

### DIFF
--- a/openspec/changes/fix-occurrence-index-misalignment-after-cancel/proposal.md
+++ b/openspec/changes/fix-occurrence-index-misalignment-after-cancel/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+`RecurringEventService::extend_horizon` assigns `occurrence_index` to newly materialized occurrences by deriving the next index from `MAX(occurrence_index)` over the *surviving* `events` rows:
+
+```rust
+// src/service/recurring_event_service.rs:235-248
+let next_index = self
+    .event_repo
+    .max_occurrence_index_for_series(series.id)   // SELECT MAX(occurrence_index) FROM events WHERE series_id = ?
+    .await?
+    .unwrap_or(0);
+...
+for (i, start) in new_times.iter().enumerate() {
+    let occurrence_index = next_index + (i as i32) + 1;
+```
+
+But `occurrence_index` is meant to be the **1-based position in the recurrence stream**, and that is how initial materialization assigns it: `create_series_with_initial_materialization` numbers by stream position and consumes an index even for cancelled occurrences (`src/service/recurring_event_service.rs:136-148` — the loop uses `(idx + 1)` and only `continue`s for a cancelled index *after* consuming it). The materializer then keys exception lookups on that index (`Materializer respects per-occurrence exceptions`, `openspec/specs/event-admin-service/spec.md:86-106`).
+
+These two index sources diverge after a boundary cancellation. `cancel_event_occurrence` inserts a `Cancelled` exception for the index AND **hard-deletes the `events` row** (`src/service/event_admin_service.rs:393-407`) without adjusting `series.materialized_through`. So if the highest-numbered materialized occurrence is cancelled, `MAX(occurrence_index)` drops below the true stream position of `materialized_through`.
+
+Triggering scenario (weekly series, admin-reachable):
+1. A series materializes occurrences 1..52; `materialized_through` = occurrence #52's start.
+2. An admin cancels occurrence #52 (the boundary occurrence). Its `events` row is deleted, a `Cancelled` exception is stored for index 52, and `materialized_through` is left unchanged. Now `MAX(occurrence_index) = 51`.
+3. The daily horizon-roll calls `extend_horizon`. It generates new occurrences starting at `materialized_through + 1s` — i.e. the stream's #53, #54, … — but `next_index = 51`, so the first new occurrence is assigned `occurrence_index = 52`.
+4. The loop calls `find_exception(series, 52)`, finds the `Cancelled` exception left by step 2, and **skips the occurrence** (`continue`, `src/service/recurring_event_service.rs:254-259`).
+
+Harm: a legitimate future occurrence is silently never created (it never appears on the calendar / RSVP list), and every subsequent index is shifted down by the number of trailing cancelled occurrences. The shift also corrupts `restore_event_occurrence`'s index-based start-time recomputation for later occurrences. This is data corruption that compounds on each horizon-roll, and it directly violates the spec's guarantee that the materializer consults `event_series_exceptions` for the correct `(series_id, occurrence_index)` pair.
+
+## What Changes
+
+Make `extend_horizon` number new occurrences by their **true stream position** rather than by `MAX(occurrence_index)` of surviving rows, so a cancelled (and deleted) boundary occurrence no longer shifts later indices.
+
+Concretely: compute the index offset from the recurrence stream itself. The materializer already re-derives the `anchor` (the first occurrence's start) and generates from it. Generate (or count) occurrences from the `anchor` up to `materialized_through` to determine how many stream positions precede the first new occurrence, and number the new occurrences from there — e.g. `base_index = count_of_stream_occurrences_through(materialized_through)`, then `occurrence_index = base_index + i + 1`. Equivalently, persist the last-emitted stream index on the series row and advance it. Either approach keeps the index aligned with the stream regardless of how many trailing occurrences were cancelled/deleted, matching `create_series_with_initial_materialization`.
+
+Update the `event-admin-service` spec's "Materializer respects per-occurrence exceptions" requirement to state that occurrence indices SHALL track the recurrence stream position (not surviving-row `MAX`), and add a scenario for the boundary-cancel case.
+
+## Impact
+
+- `src/service/recurring_event_service.rs` — replace the `max_occurrence_index_for_series`-based `next_index` in `extend_horizon` with a stream-position-derived base index. The `anchor`/`generate_occurrences` machinery needed to compute it is already present in the function.
+- `src/repository/event_repository.rs` — `max_occurrence_index_for_series` may become unused by this path; leave it if other callers exist, otherwise it can be removed in a follow-up (not required by this change).
+- `openspec/specs/event-admin-service/spec.md` — MODIFY "Materializer respects per-occurrence exceptions" to require stream-aligned indexing and add the boundary-cancel scenario.
+- Tests: a new test that cancels the last materialized occurrence of a series, then extends the horizon, and asserts the next real occurrence is created (not skipped) and that indices stay aligned with the stream.

--- a/openspec/changes/fix-occurrence-index-misalignment-after-cancel/specs/event-admin-service/spec.md
+++ b/openspec/changes/fix-occurrence-index-misalignment-after-cancel/specs/event-admin-service/spec.md
@@ -1,0 +1,33 @@
+# event-admin-service Specification Delta
+
+## MODIFIED Requirements
+
+### Requirement: Materializer respects per-occurrence exceptions
+
+The recurring-event materializer (both initial materialization on series creation and the daily horizon-roll) SHALL consult `event_series_exceptions` for each `(series_id, occurrence_index)` pair it would otherwise create:
+
+- If a `cancelled` exception exists → no `events` row is created for that index.
+- If an `overridden` exception exists → the `events` row is created from the series template, then the `override_payload`'s non-null fields are applied on top.
+- If no exception exists → the `events` row is created from the series template as before.
+
+The materializer SHALL assign `occurrence_index` by the occurrence's **position in the recurrence stream** (counting every stream position, including those that resolve to a `cancelled` exception), consistently across initial materialization and every horizon-roll. The horizon-roll SHALL NOT derive the next index from `MAX(occurrence_index)` over surviving `events` rows, because cancelling an occurrence hard-deletes its `events` row (without lowering `series.materialized_through`); deriving from surviving rows would let a cancelled boundary occurrence shift all later indices down by one and collide a future occurrence with the past cancellation's exception.
+
+This guarantees that:
+- A cancelled occurrence does NOT reappear on the next horizon-roll.
+- An overridden occurrence's overrides do NOT get clobbered when materialization re-runs.
+- Cancelling the highest-numbered materialized occurrence does NOT cause the next horizon-roll to skip a real future occurrence or misalign later indices.
+
+#### Scenario: Cancelled occurrence stays cancelled across horizon-roll
+
+- **WHEN** an occurrence is cancelled via `cancel_event_occurrence`, then the daily materializer runs (`now + 52 weeks` extends the horizon past the cancelled occurrence's date)
+- **THEN** the materializer SHALL NOT recreate an `events` row for that occurrence index; the cancellation persists
+
+#### Scenario: Overridden occurrence overrides survive series re-edit
+
+- **WHEN** occurrence 7 has an `overridden` exception (location = "Room B"), then `update_series` is called with a cutoff before occurrence 7 (forcing re-materialization)
+- **THEN** the `events` row for occurrence 7 SHALL be re-created with the series's updated template fields AND the override's location = "Room B" applied on top
+
+#### Scenario: Cancelling the boundary occurrence does not shift later indices
+
+- **WHEN** a series is materialized through occurrence N (the current horizon boundary), an admin cancels occurrence N (deleting its `events` row and leaving `materialized_through` unchanged), and the horizon-roll then materializes further occurrences
+- **THEN** the occurrence at stream position N+1 SHALL be created (it SHALL NOT be skipped by colliding with occurrence N's `cancelled` exception), and the newly created rows SHALL carry `occurrence_index = N+1, N+2, …` matching their stream positions

--- a/openspec/changes/fix-occurrence-index-misalignment-after-cancel/tasks.md
+++ b/openspec/changes/fix-occurrence-index-misalignment-after-cancel/tasks.md
@@ -1,0 +1,15 @@
+## 1. Number new occurrences by stream position, not surviving-row MAX
+
+- [ ] 1.1 In `src/service/recurring_event_service.rs::extend_horizon`, remove the `next_index` computed from `self.event_repo.max_occurrence_index_for_series(series.id)` (lines ~235-239).
+- [ ] 1.2 Derive a stream-aligned base index instead. Using the already-computed `anchor` and parsed `rule`, count how many stream occurrences fall at or before `series.materialized_through` — e.g. `let base_index = generate_occurrences(anchor, &rule, anchor, series.materialized_through + Duration::seconds(1)).len() as i32;`. This counts the stream positions consumed through `materialized_through` regardless of whether their `events` rows were later cancelled/deleted.
+- [ ] 1.3 In the insertion loop (lines ~247-248), set `let occurrence_index = base_index + (i as i32) + 1;` so new occurrences continue the stream numbering. Confirm this matches how `create_series_with_initial_materialization` assigns `(idx + 1)` (lines ~136-148), i.e. an index is consumed per stream position even when that position is a `Cancelled` exception.
+- [ ] 1.4 Verify the exception lookup `find_exception(series.id, occurrence_index)` (lines ~249-252) now receives the correct stream index, so a `Cancelled` exception at a *past* boundary index is not re-collided with a *future* occurrence.
+
+## 2. Spec update
+
+- [ ] 2.1 Apply the `MODIFIED Requirements` block in `specs/event-admin-service/spec.md` from this change to `openspec/specs/event-admin-service/spec.md`, replacing the existing "Materializer respects per-occurrence exceptions" requirement so it additionally mandates stream-position-aligned `occurrence_index` assignment and includes the boundary-cancel scenario.
+
+## 3. Tests
+
+- [ ] 3.1 Add a test `extend_horizon_after_cancelling_boundary_occurrence_keeps_indices_aligned` (in `tests/recurring_event_test.rs` or the existing recurring-event test module): create a weekly series materialized through occurrence N (the horizon boundary), cancel occurrence N via `cancel_event_occurrence`, then call `extend_horizon` with a target past several more occurrences. Assert (a) the occurrence at stream position N+1 IS created (not skipped), and (b) the newly created rows carry `occurrence_index = N+1, N+2, …` (stream-aligned), not `N, N+1, …`.
+- [ ] 3.2 Add a regression assertion that with no cancellations, `extend_horizon` still assigns contiguous indices continuing from the prior batch (guards against off-by-one in the new base-index computation).

--- a/openspec/changes/secure-atomic-scheduled-payment-claim/proposal.md
+++ b/openspec/changes/secure-atomic-scheduled-payment-claim/proposal.md
@@ -1,0 +1,40 @@
+## Why
+
+`BillingService::process_scheduled_payment` claims a Pending scheduled payment with a check-then-act sequence that is NOT atomic:
+
+```rust
+// src/service/billing_service/auto_renew.rs:519-540
+let sp = self.scheduled_payment_repo.find_by_id(id).await? ...;
+if sp.status != ScheduledPaymentStatus::Pending {       // CHECK
+    return Err(...);
+}
+...
+self.scheduled_payment_repo
+    .update_status(id, ScheduledPaymentStatus::Processing, None)   // ACT
+    .await?;
+```
+
+`update_status` issues `UPDATE scheduled_payments SET status = ?, … WHERE id = ?` with **no status guard** (`src/repository/scheduled_payment_repository.rs:216-221`), and the `status` column has no DB constraint enforcing the transition. So two concurrent invocations for the same `id` can both pass the `!= Pending` check and both flip the row to `Processing` — a classic TOCTOU/lost-update.
+
+The Stripe charge itself is protected: the idempotency key is `sched-{sp.id}` (`auto_renew.rs:596`), so Stripe returns the same PaymentIntent and the member's bank is not double-charged. **But the local side effects are not idempotent across racers.** Each racer mints its own `payment_id = Uuid::new_v4()` (`auto_renew.rs:603`), inserts its own `payments` row (`auto_renew.rs:636`), and calls `extend_member_dues(payment.id, …)` (`auto_renew.rs:647`), which is idempotent only per `payment_id` (`src/repository/payment_repository.rs:472-543`). Two distinct `payment_id`s → **dues extended twice** (e.g. +2 years for one charge) and two `Completed` payment rows for a single Stripe charge.
+
+Trigger / precondition: this is reachable whenever `process_scheduled_payment` runs concurrently for the same id — multiple app processes sharing the SQLite database, or any future concurrent/overlapping invocation of the runner. (The current single-process `BillingRunner` loop is sequential, so a default single-process deployment does not hit it today; this is a latent atomicity gap, not an externally attacker-triggered exploit.) Harm: financial-record corruption (double dues credit, duplicate completed payments) that is hard to detect and unwind.
+
+The codebase already establishes the correct pattern elsewhere — `complete_pending_payment` and `claim_payment_for_refund` use a compare-and-swap `UPDATE … WHERE … status = '<expected>'` and check `rows_affected() == 1`. This change applies the same idiom to the scheduled-payment claim.
+
+## What Changes
+
+Make the Pending→Processing transition an atomic compare-and-swap so only one caller can claim a given scheduled payment:
+
+- Add a repository method (e.g. `claim_for_processing(id) -> Result<bool>`) that runs `UPDATE scheduled_payments SET status = 'processing', last_attempt_at = ?, updated_at = ? WHERE id = ? AND status = 'pending'` and returns whether exactly one row was updated (`rows_affected() == 1`).
+- In `process_scheduled_payment`, replace the `find_by_id` + `!= Pending` check + unconditional `update_status(Processing)` with: fetch the row for its data, then call `claim_for_processing(id)`; if it returns `false`, bail out (the row was already claimed/not pending) without charging.
+- Leave the existing `update_status` calls for the later Failed/Completed transitions as-is (those are reached only by the single winner that holds the claim).
+
+Add an `ADDED` requirement to the `scheduled-payments` spec that the Pending→Processing transition is an atomic compare-and-swap and that a lost claim does not charge or extend dues.
+
+## Impact
+
+- `src/repository/scheduled_payment_repository.rs` — add `claim_for_processing` (atomic guarded UPDATE returning a bool); add it to the `ScheduledPaymentRepository` trait and the Sqlite impl.
+- `src/service/billing_service/auto_renew.rs` — `process_scheduled_payment` uses the atomic claim and returns early on a lost claim (treat as a no-op `Ok(())`, since another worker owns it).
+- `openspec/specs/scheduled-payments/spec.md` — new requirement: atomic claim of a Pending scheduled payment.
+- Tests: a test asserting that a second `claim_for_processing` on an already-`processing` row returns `false`, and that `process_scheduled_payment` short-circuits (no new `payments` row, no dues extension) when the claim is lost.

--- a/openspec/changes/secure-atomic-scheduled-payment-claim/specs/scheduled-payments/spec.md
+++ b/openspec/changes/secure-atomic-scheduled-payment-claim/specs/scheduled-payments/spec.md
@@ -1,0 +1,24 @@
+# scheduled-payments Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Pending→Processing transition is an atomic compare-and-swap
+
+Claiming a scheduled payment for processing SHALL be an atomic compare-and-swap: the transition from `pending` to `processing` SHALL be performed by a single guarded statement (`UPDATE scheduled_payments SET status = 'processing', … WHERE id = ? AND status = 'pending'`) whose `rows_affected()` determines whether the caller won the claim. `process_scheduled_payment` SHALL NOT use a separate read-then-unconditional-write (which permits two concurrent callers to both pass a `status == pending` check and both proceed).
+
+A caller that loses the claim (the guarded update affects zero rows) SHALL NOT charge the card, SHALL NOT create a `payments` row, and SHALL NOT extend the member's dues; it returns without side effects. This prevents a concurrency window in which two callers each mint a distinct `payment_id` for the same scheduled payment and each extend dues — the per-`payment_id` idempotency of dues extension does not protect against distinct `payment_id`s for one charge.
+
+#### Scenario: Only one concurrent caller claims a pending scheduled payment
+
+- **WHEN** two callers attempt to process the same `pending` scheduled payment concurrently
+- **THEN** exactly one guarded `claim_for_processing` update SHALL affect one row (the winner), the other SHALL affect zero rows (the loser), and only the winner SHALL charge the card and extend dues
+
+#### Scenario: Lost claim performs no side effects
+
+- **WHEN** `process_scheduled_payment` is invoked for a scheduled payment whose status is already `processing` (already claimed by another worker)
+- **THEN** the call SHALL return successfully without charging the card, without creating a new `payments` row, and without changing the member's `dues_paid_until`
+
+#### Scenario: A non-pending scheduled payment is not reprocessed
+
+- **WHEN** `process_scheduled_payment` is invoked for a scheduled payment whose status is `completed`, `failed`, or `canceled`
+- **THEN** the atomic claim SHALL affect zero rows and the call SHALL perform no charge and no dues extension

--- a/openspec/changes/secure-atomic-scheduled-payment-claim/tasks.md
+++ b/openspec/changes/secure-atomic-scheduled-payment-claim/tasks.md
@@ -1,0 +1,25 @@
+## 1. Add an atomic claim to the scheduled-payment repository
+
+- [ ] 1.1 In `src/repository/scheduled_payment_repository.rs`, add a method to the `ScheduledPaymentRepository` trait: `async fn claim_for_processing(&self, id: Uuid) -> Result<bool>;`.
+- [ ] 1.2 Implement it on the Sqlite repo with a guarded compare-and-swap:
+  ```sql
+  UPDATE scheduled_payments
+  SET status = 'processing', last_attempt_at = ?, updated_at = ?
+  WHERE id = ? AND status = 'pending'
+  ```
+  Bind the current timestamp twice and the id, then return `Ok(result.rows_affected() == 1)`. Mirror the existing compare-and-swap style used by `complete_pending_payment` / `claim_payment_for_refund` in `src/repository/payment_repository.rs`.
+
+## 2. Use the atomic claim in process_scheduled_payment
+
+- [ ] 2.1 In `src/service/billing_service/auto_renew.rs::process_scheduled_payment`, keep the initial `find_by_id(id)` fetch (the handler still needs `member_id`, `amount_cents`, `membership_type_id`, etc.), but remove the unconditional `update_status(id, Processing, None)` flip at lines ~538-540.
+- [ ] 2.2 After confirming the fetched row exists, call `let claimed = self.scheduled_payment_repo.claim_for_processing(id).await?;`. If `!claimed`, return `Ok(())` (another worker owns this payment, or it is no longer pending) WITHOUT charging or extending dues. This replaces the prior `if sp.status != Pending { return Err(...) }` early-return.
+- [ ] 2.3 Leave the subsequent `update_status(..., Failed, ...)` and `update_status(..., Completed, ...)` calls unchanged — they run only for the single claim winner.
+
+## 3. Spec update
+
+- [ ] 3.1 Apply the `ADDED Requirements` block from `specs/scheduled-payments/spec.md` in this change to `openspec/specs/scheduled-payments/spec.md`.
+
+## 4. Tests
+
+- [ ] 4.1 Add a repository test `claim_for_processing_is_single_flight`: insert a Pending scheduled payment, assert the first `claim_for_processing(id)` returns `true` and flips status to `processing`, and a second `claim_for_processing(id)` returns `false` and leaves status `processing`.
+- [ ] 4.2 Add a service test `process_scheduled_payment_noops_when_claim_lost`: pre-set the scheduled payment to `processing` (simulating a racer that already claimed it), call `process_scheduled_payment(id)`, and assert it returns `Ok(())` with NO new `payments` row created and NO change to the member's `dues_paid_until` (no dues extension).

--- a/openspec/changes/secure-reject-empty-stripe-webhook-secret/proposal.md
+++ b/openspec/changes/secure-reject-empty-stripe-webhook-secret/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+The Stripe wiring in `src/main.rs` is documented to enable Stripe "only when both an API key AND a webhook secret are configured; missing either disables Stripe entirely" (`src/main.rs:209-211`). The actual check does NOT enforce that invariant for a *blank* value:
+
+```rust
+// src/main.rs:212-217
+let stripe_client = if settings.stripe.enabled {
+    match (
+        settings.stripe.secret_key.clone(),
+        settings.stripe.webhook_secret.clone(),
+    ) {
+        (Some(api_key), Some(_)) => { /* Stripe enabled */ }
+```
+
+`webhook_secret` is an `Option<String>` (`src/config/mod.rs:169`) and the shipped `config.toml:32` sets `webhook_secret = ""`. An empty string deserializes to `Some("")`, which matches `Some(_)`. The dispatcher is then built with that empty secret (`src/main.rs:434-449` — `webhook_secret.clone().map(|webhook_secret| WebhookDispatcher::new(.., webhook_secret, ..))`), and verification runs against it (`src/payments/webhook_dispatcher/mod.rs:78` — `Webhook::construct_event(payload, sig, &self.webhook_secret)`).
+
+HMAC-SHA256 accepts a zero-length key, so `construct_event` with an empty secret still "verifies" — but the signature is `HMAC-SHA256("", "{t}.{payload}")`, which **any unauthenticated caller can compute themselves**. The endpoint also only requires the timestamp to be within Stripe's ±300s tolerance, which an attacker trivially satisfies with a current timestamp.
+
+Attacker / input: an unauthenticated POST to `/api/payments/webhook/stripe` with a self-computed `Stripe-Signature` header, when the operator has set `stripe.enabled = true` and a real `secret_key` but left `webhook_secret` blank (the value the default `config.toml` ships, and the value produced by an unset `COTERIE__STRIPE__WEBHOOK_SECRET=` env override).
+
+Harm: forged webhook events are processed as genuine. A forged `checkout.session.completed` / `payment_intent.succeeded` can flip a Pending `payments` row to Completed and **extend a member's dues without any real payment** (`src/payments/webhook_dispatcher/checkout.rs`, `payment_intent.rs`); a forged `charge.refunded` can mark payments Refunded; a forged `customer.subscription.deleted` can flip a member's billing mode. This is an authentication bypass on a money-moving endpoint.
+
+The correct fail-safe already exists: when the dispatcher is `None`, the handler returns `503` without processing (`src/api/handlers/payments.rs:47-50`). The fix is simply to make a blank secret resolve to `None` (i.e. "not configured") instead of `Some("")`.
+
+## What Changes
+
+In `src/main.rs`, before the `match`, normalize blank Stripe credentials to `None` so the existing "missing either disables Stripe" logic treats an empty string the same as an absent value:
+
+- Treat `webhook_secret` whose trimmed value is empty as not configured (→ `None`), so the webhook dispatcher is built as `None` and the endpoint returns `503` instead of accepting forged events.
+- Apply the same normalization to `secret_key` so a blank API key cannot enable a half-configured Stripe.
+- When `stripe.enabled = true` but either normalized value is `None`, keep the existing `tracing::warn!("Stripe enabled but missing configuration")` so the misconfiguration is visible in logs at boot.
+
+Add an `ADDED` requirement to the `stripe-webhook` spec stating that a blank/whitespace webhook secret SHALL be treated as unconfigured and SHALL NOT enable webhook processing.
+
+## Impact
+
+- `src/main.rs` — normalize `settings.stripe.secret_key` and `settings.stripe.webhook_secret` with `.filter(|s| !s.trim().is_empty())` before the wiring match (covers both the file-config default `webhook_secret = ""` and the env-var `COTERIE__STRIPE__WEBHOOK_SECRET=` path).
+- `openspec/specs/stripe-webhook/spec.md` — new requirement: blank webhook secret disables the endpoint.
+- Tests: a unit test asserting the normalization helper maps `Some("")` / `Some("   ")` → `None`, plus an integration-style assertion that a `WebhookDispatcher` is not constructed when the secret is blank.
+
+Operator follow-up (NOT an implementer task): any deployment currently running with `stripe.enabled = true` and a blank `webhook_secret` has been accepting forgeable webhooks; after this fix the endpoint returns `503` until a real secret is set. Such deployments SHOULD set a genuine `whsec_…` value and audit recent Pending→Completed payment transitions for ones not backed by a real Stripe charge.

--- a/openspec/changes/secure-reject-empty-stripe-webhook-secret/specs/stripe-webhook/spec.md
+++ b/openspec/changes/secure-reject-empty-stripe-webhook-secret/specs/stripe-webhook/spec.md
@@ -1,0 +1,24 @@
+# stripe-webhook Specification Delta
+
+## ADDED Requirements
+
+### Requirement: Blank webhook secret is treated as unconfigured
+
+A blank or whitespace-only Stripe webhook secret SHALL be treated as "not configured" and SHALL NOT enable webhook processing. The application startup wiring SHALL normalize `stripe.webhook_secret` (and `stripe.secret_key`) so that `Some("")` or `Some("   ")` resolves to `None`, the same as an absent value. When `stripe.enabled = true` but the normalized webhook secret is `None`, the `WebhookDispatcher` SHALL NOT be constructed and `POST /api/payments/webhook/stripe` SHALL return `503 Service Unavailable` without parsing or acting on the request body.
+
+This closes a forgery path: an empty secret would otherwise be used as an HMAC-SHA256 key (which accepts a zero-length key), letting any unauthenticated caller compute a "valid" `Stripe-Signature` for an arbitrary payload and have forged events processed as genuine.
+
+#### Scenario: Empty-string webhook secret does not enable the endpoint
+
+- **WHEN** the application boots with `stripe.enabled = true`, a non-blank `secret_key`, and `webhook_secret = ""` (the value shipped in `config.toml`, or an unset `COTERIE__STRIPE__WEBHOOK_SECRET=` env override)
+- **THEN** the webhook dispatcher SHALL NOT be constructed AND a POST to `/api/payments/webhook/stripe` SHALL return `503` without processing the payload
+
+#### Scenario: Whitespace-only webhook secret is rejected
+
+- **WHEN** `webhook_secret` is set to a whitespace-only string such as `"   "`
+- **THEN** startup SHALL treat it as unconfigured (normalized to `None`) exactly as an empty string
+
+#### Scenario: Genuine webhook secret still enables the endpoint
+
+- **WHEN** the application boots with `stripe.enabled = true`, a non-blank `secret_key`, and a non-blank `webhook_secret` (e.g. `whsec_…`)
+- **THEN** the webhook dispatcher SHALL be constructed and signature verification SHALL run against the configured secret as before

--- a/openspec/changes/secure-reject-empty-stripe-webhook-secret/tasks.md
+++ b/openspec/changes/secure-reject-empty-stripe-webhook-secret/tasks.md
@@ -1,0 +1,19 @@
+## 1. Treat a blank Stripe webhook secret (and API key) as unconfigured
+
+- [ ] 1.1 In `src/main.rs`, immediately before the `match (settings.stripe.secret_key.clone(), settings.stripe.webhook_secret.clone())` at line ~212, bind normalized locals, e.g.:
+  ```rust
+  let secret_key = settings.stripe.secret_key.clone().filter(|s| !s.trim().is_empty());
+  let webhook_secret = settings.stripe.webhook_secret.clone().filter(|s| !s.trim().is_empty());
+  ```
+  and match on `(secret_key.clone(), webhook_secret.clone())` instead of the raw `settings.stripe.*` values, so `Some("")` / `Some("   ")` become `None`.
+- [ ] 1.2 In the webhook-dispatcher wiring at `src/main.rs:434-449`, use the same normalized `webhook_secret` local (not `settings.stripe.webhook_secret.clone()`) so a blank secret yields `webhook_dispatcher = None` and the endpoint falls through to the existing `503` path in `src/api/handlers/payments.rs:47-50`.
+- [ ] 1.3 Keep the existing `tracing::warn!("Stripe enabled but missing configuration")` arm so a deployment with `stripe.enabled = true` but a blank key/secret logs the misconfiguration at boot.
+
+## 2. Spec update
+
+- [ ] 2.1 Add the `ADDED Requirements` block from `specs/stripe-webhook/spec.md` in this change to `openspec/specs/stripe-webhook/spec.md`: a blank/whitespace webhook secret SHALL be treated as unconfigured and SHALL NOT enable webhook processing.
+
+## 3. Tests
+
+- [ ] 3.1 Factor the blank-to-`None` normalization into a small pure helper (e.g. `fn nonblank(s: Option<String>) -> Option<String>`) in `src/config/mod.rs` or `src/main.rs`, and add a unit test asserting `nonblank(Some("".into())) == None`, `nonblank(Some("  ".into())) == None`, `nonblank(Some("whsec_x".into())) == Some("whsec_x".into())`, and `nonblank(None) == None`.
+- [ ] 3.2 Add a test that constructs a `StripeConfig { enabled: true, secret_key: Some("sk_test_x".into()), webhook_secret: Some("".into()), .. }`, runs it through the normalization used by the wiring, and asserts the webhook-secret side resolves to `None` (i.e. no dispatcher would be built). Keep the assertion at the config/normalization layer so it needs no live server or network.


### PR DESCRIPTION
This PR ships audit-produced proposals only — no implementer changes this iteration.

## Audit-produced proposals

- audit: security-bug proposals (3 change(s))

Each `audit: <type>` commit creates new `openspec/changes/<prefix>-*` directories that the next polling iteration will pick up via `list_pending` and route to the implementer.
