### PR TITLE
audit-only: 1 proposal(s) from security-bug

### DIFF
--- a/openspec/changes/fix-csrf-blocks-web-auth-endpoints/proposal.md
+++ b/openspec/changes/fix-csrf-blocks-web-auth-endpoints/proposal.md
@@ -1,0 +1,94 @@
+## Why
+
+The top-level CSRF layer rejects every browser-facing authentication POST,
+locking the entire web portal out of its own login, 2FA, password-reset, and
+first-run-setup flows.
+
+`csrf_protect_unless_exempt` is layered as the OUTERMOST middleware on the
+merged application router in `src/main.rs:541-550` (CSRF is added last, so it
+runs first). For any state-changing method that is NOT GET/HEAD/OPTIONS and NOT
+in `CSRF_EXEMPT_PATHS`, the middleware requires a `session` cookie before it will
+look at anything else:
+
+```rust
+// src/api/middleware/security.rs:132
+let session_cookie = jar.get("session").ok_or(AppError::Forbidden)?;
+```
+
+The exempt list (`src/api/middleware/security.rs:82-88`) names the JSON API
+auth endpoints `/auth/login` and `/auth/login/totp` — but the browser portal's
+forms POST to the WEB routes, which are different paths and are NOT exempt:
+
+- `templates/auth/login.html:21` → `hx-post="/login"`
+- `templates/auth/login_totp.html:18` → `hx-post="/login/totp"`
+- `templates/auth/forgot_password.html:24` → `action="/forgot-password"`
+- `templates/auth/reset_password.html:16` → `action="/reset-password"`
+- `templates/auth/setup.html:18` → `hx-post="/setup"`
+
+These routes are registered in `src/web/mod.rs:31-57` and merged into the app,
+so the top-level CSRF layer covers them (the same way it covers `/portal/*` —
+see `tests/csrf_coverage_test.rs`, which proves a session-less POST to a merged
+web route is rejected with 403). The callers of all five are by definition
+session-less: `login_page` (`src/web/templates/auth.rs:51-82`) renders the login
+form WITHOUT setting any `session` cookie; the `/login/totp` step holds only a
+`pending_login` cookie; `/forgot-password` and `/reset-password` are anonymous;
+`/setup` runs before any admin or session exists.
+
+**Concrete harm (availability / authentication lockout).** Every anonymous POST
+to `/login`, `/login/totp`, `/forgot-password`, `/reset-password`, or `/setup`
+hits the `jar.get("session").ok_or(AppError::Forbidden)` branch and returns
+**403 Forbidden before the handler ever runs**. The result:
+
+- Nobody can log in through the portal (the only admin surface — see README).
+- A member with 2FA cannot complete the second factor.
+- Nobody can request or complete a password reset.
+- A freshly provisioned instance cannot run the in-app first-run setup wizard.
+
+A user already holding a live `session` cookie is unaffected, which is why the
+break is invisible until a session expires or a new user arrives — and why no
+test catches it: the web-auth integration tests
+(`tests/web_login_session_create_fail.rs:62-64`, `tests/web_login_totp.rs`)
+build `web::create_web_routes(state)` in ISOLATION, bypassing the top-level CSRF
++ setup layers, so they exercise the handler but never the production middleware
+stack.
+
+**Contract change (stated plainly).** The canonical `csrf-protection` spec's
+"Exempt list is small, explicit, and justified" requirement enumerates the
+exempt paths and currently lists `POST /auth/login` / `POST /auth/login/totp`.
+This change corrects that enumerated, observable contract: the actual web-auth
+POST endpoints (`/login`, `/login/totp`, `/forgot-password`, `/reset-password`,
+`/setup`) are added to the exempt set, because — exactly like `/public/signup`
+and `/auth/login` already on the list — they exist to authenticate a caller who
+has no session yet and so cannot carry a session-bound CSRF token. Their
+non-CSRF protections remain: the per-IP login/`money` rate limiters,
+SameSite=Lax cookies, the enumeration-safe forgot-password response, the
+single-use time-limited reset token, and the one-shot `setup_lock` +
+"no admin yet" gate.
+
+## What Changes
+
+- Add the five session-less web-auth POST paths to `CSRF_EXEMPT_PATHS` in
+  `src/api/middleware/security.rs`, each with the required justification comment:
+  `POST /login`, `POST /login/totp`, `POST /forgot-password`,
+  `POST /reset-password`, `POST /setup`. The existing entries (including the JSON
+  `/auth/login` and `/auth/login/totp`, which still exist in `src/api/mod.rs`)
+  are retained.
+- Update the doc comment above the list so each new entry carries its
+  "cannot carry a session-bound CSRF token because…" rationale.
+- Update the `csrf-protection` capability spec's "Exempt list is small,
+  explicit, and justified" requirement to enumerate the web-auth paths and add a
+  scenario asserting an anonymous web-auth POST is forwarded (not 403'd).
+- Add a regression integration test that builds the FULL merged app (CSRF layer
+  included, the way `tests/csrf_coverage_test.rs` does) and asserts each of the
+  five anonymous web-auth POSTs is NOT rejected with 403 by the CSRF layer.
+
+## Impact
+
+- `src/api/middleware/security.rs` — extend `CSRF_EXEMPT_PATHS` and its doc
+  comment.
+- `openspec/specs/csrf-protection/spec.md` — modified by this change's
+  `specs/csrf-protection/spec.md` delta (folded into canon at archive time).
+- `tests/` — new full-stack regression test proving the web-auth POSTs pass the
+  CSRF layer. (The existing isolated web-login tests stay; they do not cover the
+  merged middleware stack.)
+- No operator action required.

--- a/openspec/changes/fix-csrf-blocks-web-auth-endpoints/specs/csrf-protection/spec.md
+++ b/openspec/changes/fix-csrf-blocks-web-auth-endpoints/specs/csrf-protection/spec.md
@@ -1,0 +1,35 @@
+## MODIFIED Requirements
+
+### Requirement: Exempt list is small, explicit, and justified
+
+The set of CSRF-exempt paths SHALL be a static list in `src/api/middleware/security.rs` named `CSRF_EXEMPT_PATHS`. Adding to the list SHALL require a documented "this endpoint cannot carry a session-bound CSRF token because…" justification.
+
+The exempt entries SHALL include every state-changing endpoint whose caller has no `session` cookie at the time of the request — otherwise the top-level CSRF layer rejects it with 403 before its handler runs. The current exempt entries are:
+
+- `POST /api/payments/webhook/stripe` — Stripe HMAC signature is the auth.
+- `POST /public/signup` — cross-origin from marketing site; gated by CORS allowlist + rate limit + bot challenge.
+- `POST /public/donate` — same as signup.
+- `POST /login` — the browser portal login form (`templates/auth/login.html`) posts here; no session exists yet to bind a token to. Gated by the per-IP login rate limiter and SameSite=Lax cookies.
+- `POST /login/totp` — the second-factor step of the portal login; the caller holds only a `pending_login` cookie at this step, not a `session` cookie, so there is no session id to bind a CSRF token to.
+- `POST /forgot-password` — anonymous password-reset request; no session. Gated by the per-IP login rate limiter and an enumeration-safe response.
+- `POST /reset-password` — anonymous; authorization is the single-use, time-limited reset token carried in the form body, not a session.
+- `POST /setup` — the first-run admin-creation wizard; runs before any admin or session exists. Gated by the one-shot "no admin yet" check + `setup_lock`.
+- `POST /auth/login` — JSON login API; no session exists yet to bind a token to.
+- `POST /auth/login/totp` — JSON second-factor API; same reason as `/auth/login`: the caller holds only a `pending_login` cookie, not a `session` cookie.
+
+`POST /logout` and `POST /auth/logout` are NOT exempt: every authenticated page renders a CSRF meta tag, the caller holds a valid session, and forced logout warrants protection.
+
+#### Scenario: Adding to the exempt list requires a justification
+
+- **WHEN** a change adds an entry to `CSRF_EXEMPT_PATHS`
+- **THEN** the change description MUST state why the endpoint cannot carry a session-bound token
+
+#### Scenario: Anonymous web-auth POST is exempt, not rejected
+
+- **WHEN** an anonymous POST to `/login`, `/login/totp`, `/forgot-password`, `/reset-password`, or `/setup` arrives with no `session` cookie
+- **THEN** the top-level CSRF middleware SHALL treat the path as exempt and forward the request to its handler, NOT respond 403 — because these endpoints exist to authenticate (or first-provision) a caller who has no session yet and therefore cannot present a session-bound CSRF token
+
+#### Scenario: Logout is not exempt
+
+- **WHEN** a logout POST arrives without a valid CSRF token
+- **THEN** the middleware SHALL reject it with 403 Forbidden

--- a/openspec/changes/fix-csrf-blocks-web-auth-endpoints/tasks.md
+++ b/openspec/changes/fix-csrf-blocks-web-auth-endpoints/tasks.md
@@ -1,0 +1,53 @@
+## 1. Add the web-auth POST paths to the CSRF exempt list
+
+- [ ] 1.1 In `src/api/middleware/security.rs`, extend the `CSRF_EXEMPT_PATHS`
+  array (currently at lines 82-88) to add these five entries, keeping the
+  existing entries intact:
+  - `("POST", "/login")`
+  - `("POST", "/login/totp")`
+  - `("POST", "/forgot-password")`
+  - `("POST", "/reset-password")`
+  - `("POST", "/setup")`
+- [ ] 1.2 Extend the doc comment block above `CSRF_EXEMPT_PATHS` so each new
+  entry carries its "cannot carry a session-bound CSRF token because…"
+  justification:
+  - `/login` — the browser login form (`login.html`) posts here; no `session`
+    cookie exists yet to bind a token to.
+  - `/login/totp` — the second-factor step; the caller holds only a
+    `pending_login` cookie, not a `session` cookie.
+  - `/forgot-password` — anonymous reset request; no session; gated by the
+    per-IP login rate limiter and an enumeration-safe response.
+  - `/reset-password` — anonymous; authorization is the single-use,
+    time-limited reset token in the form body, not a session.
+  - `/setup` — first-run admin-creation wizard; runs before any admin or
+    session exists; gated by the one-shot "no admin yet" check + `setup_lock`.
+- [ ] 1.3 Do NOT remove the existing `("POST", "/auth/login")` and
+  `("POST", "/auth/login/totp")` entries — the JSON login handlers they refer to
+  still exist in `src/api/mod.rs` and are still legitimately session-less.
+
+## 2. Regression test: anonymous web-auth POSTs pass the CSRF layer
+
+- [ ] 2.1 Add an integration test (e.g. `tests/csrf_web_auth_exempt_test.rs`)
+  that builds the FULL merged application exactly as `main.rs` does — mirror the
+  `build_app()` helper in `tests/csrf_coverage_test.rs:45-157`: construct the
+  `AppState`, then
+  `api::create_app(state).merge(web::create_web_routes(state)).layer(require_setup).layer(csrf_protect_unless_exempt)`.
+- [ ] 2.2 For each path in `["/login", "/login/totp", "/forgot-password",
+  "/reset-password", "/setup"]`, send a POST with NO `session` cookie (use a
+  well-formed body for its content type — e.g. JSON `{"username":"nobody",
+  "password":"x"}` for `/login`) and assert the response status is NOT
+  `StatusCode::FORBIDDEN`. Add a comment: a 403 here is the CSRF-layer rejection
+  this change fixes; any other status proves the request reached its handler.
+- [ ] 2.3 Keep one assertion that a still-protected route remains guarded — POST
+  `/portal/admin/members/<uuid>/update` with no session SHALL still return
+  `403 Forbidden` — so the test proves the exempt list was widened precisely, not
+  that CSRF was globally disabled.
+
+## 3. Spec delta
+
+- [ ] 3.1 The `specs/csrf-protection/spec.md` delta in this change updates the
+  "Exempt list is small, explicit, and justified" requirement (enumeration +
+  new scenario). No code action beyond Task 1 is needed; canon is folded at
+  archive time.
+- [ ] 3.2 Run `openspec validate --strict` for this change and resolve any
+  reported issues before marking the change ready.


### PR DESCRIPTION
This PR ships audit-produced proposals only — no implementer changes this iteration.

## Audit-produced proposals

- audit: security-bug proposals (1 unit(s))

Each `audit: <type>` commit creates new `openspec/changes/<prefix>-*` directories that the next polling iteration will pick up via `list_pending` and route to the implementer.
