### PR TITLE
audit-only: 4 proposal(s) from missing-tests

### DIFF
--- a/issues/tests-admin-alert-email-skip-and-send-failure/issue.md
+++ b/issues/tests-admin-alert-email-skip-and-send-failure/issue.md
@@ -1,0 +1,48 @@
+# tests-admin-alert-email-skip-and-send-failure
+
+## Coverage gap
+
+`AdminAlertEmailIntegration::handle_event`
+(`src/integrations/admin_alert_email.rs:60-111`) has **no tests at all** —
+it is referenced only by wiring in `src/main.rs` and
+`src/integrations/mod.rs`. Two of its branches are the integration's whole
+reason to exist, and both are untested:
+
+1. **Skip when no recipient is configured.** `handle_event` reads
+   `org.contact_email`, and when it is missing/empty it logs and returns
+   `Ok(())` without calling the sender
+   (`src/integrations/admin_alert_email.rs:64-74`).
+2. **Send failure is absorbed, never propagated.** When
+   `self.sender.send(...)` returns `Err`, the handler logs it and still
+   returns `Ok(())` (`src/integrations/admin_alert_email.rs:107-110`).
+   A template render failure is absorbed the same way (lines 100-103).
+
+There is also the happy path: with `org.contact_email` set, an
+`IntegrationEvent::AdminAlert` SHALL produce exactly one send to that
+address — currently unverified.
+
+## Acceptance criteria (against existing canon)
+
+This pins behavior already required by the **admin-alert-email**
+capability, `openspec/specs/admin-alert-email/spec.md`:
+
+- Requirement **"Outbound admin-alert channel for security/billing
+  events"**, Scenario **"Email failure does not abort the originating
+  service call"**:
+  > - **WHEN** an admin alert fails to send (SMTP timeout)
+  > - **THEN** the originating service call SHALL still complete and the email failure SHALL be logged for observability
+
+  Acceptance: a sender that returns `Err` SHALL cause `handle_event` to
+  return `Ok(())` (the error is not propagated).
+
+- Requirement **"Recipients are configured by setting, not hardcoded"**
+  ("when `org.contact_email` is empty the channel SHALL skip sending") and
+  its Scenario **"Recipient setting drives the To: list"**:
+  > - **WHEN** an admin updates `org.contact_email`
+  > - **THEN** subsequent admin alerts SHALL go to the new recipient without redeploy
+
+  Acceptance: with `org.contact_email` empty the sender is **not** called;
+  with it set, the alert is sent to exactly that address.
+
+No production code changes. Test-only addition; no existing test is
+modified or deleted.

--- a/issues/tests-admin-alert-email-skip-and-send-failure/tasks.md
+++ b/issues/tests-admin-alert-email-skip-and-send-failure/tasks.md
@@ -1,0 +1,46 @@
+# Tasks
+
+Add a new integration test file `tests/admin_alert_email_test.rs`. Build
+`AdminAlertEmailIntegration::new(settings, sender)` directly:
+
+- `settings` = `Arc::new(SettingsService::new(pool.clone(), crypto))` with
+  `crypto = Arc::new(SecretCrypto::new("test-secret-please-ignore"))` and
+  `pool = common::fresh_pool().await` — the same construction used in
+  `tests/auto_renew_alert_test.rs`.
+- Seed `org.contact_email` (and, where needed, `org.name`) by raw
+  `INSERT`/`UPDATE` into the `settings` table that `SettingsService::get_value`
+  reads (mirror the direct-SQL settings seeding in
+  `tests/expiration_test.rs`). For the "skip" case, leave `org.contact_email`
+  empty/unset.
+- Define two tiny in-test `EmailSender` impls: a `RecordingSender`
+  (`Arc<Mutex<Vec<EmailMessage>>>`, returns `Ok(())`) and a `FailingSender`
+  (returns `Err(AppError::External(...))`). `NoopEmailSender` in
+  `tests/auto_renew_alert_test.rs` is the pattern to copy.
+
+Invoke the handler via the `Integration` trait:
+`integration.handle_event(&IntegrationEvent::AdminAlert { subject, body })`.
+
+## 1. Empty recipient setting → no send
+- [ ] 1.1 `admin_alert_email_skips_when_contact_email_unset` — with
+  `org.contact_email` empty/unset and a `RecordingSender`, call
+  `handle_event(&AdminAlert { subject: "x".into(), body: "y".into() })`;
+  assert it returns `Ok(())` AND the recorder is empty (sender never called).
+
+## 2. Send failure is absorbed, not propagated
+- [ ] 2.1 `admin_alert_email_send_failure_is_swallowed` — with
+  `org.contact_email = "ops@example.org"` and a `FailingSender`, call
+  `handle_event(&AdminAlert { .. })`; assert it returns `Ok(())` (the
+  sender's `Err` does not surface).
+
+## 3. Configured recipient drives the To: list
+- [ ] 3.1 `admin_alert_email_sends_to_configured_recipient` — with
+  `org.contact_email = "ops@example.org"` and a `RecordingSender`, call
+  `handle_event(&AdminAlert { .. })`; assert it returns `Ok(())`, the
+  recorder holds exactly one `EmailMessage`, and that message's recipient
+  equals `"ops@example.org"`.
+
+## 4. Non-AdminAlert events are a no-op
+- [ ] 4.1 `admin_alert_email_ignores_non_alert_events` — with a
+  `RecordingSender`, call `handle_event` with any non-`AdminAlert`
+  `IntegrationEvent` variant; assert it returns `Ok(())` and the recorder is
+  empty.

--- a/issues/tests-in-use-type-deletion-refusal/issue.md
+++ b/issues/tests-in-use-type-deletion-refusal/issue.md
@@ -1,0 +1,62 @@
+# tests-in-use-type-deletion-refusal
+
+## Coverage gap
+
+The configurable-type services refuse to delete a type that is still
+referenced by existing rows, returning `AppError::Conflict`. The
+**rejection branch is untested** — every existing delete test deletes a
+type that is *not* in use, so only the happy "delete unused type" path
+is exercised.
+
+Three delete guards have no test for the in-use case:
+
+- `MembershipTypeService::delete` —
+  `src/service/membership_type_service.rs:100-117`. When
+  `repo.count_usage(id) > 0` it returns
+  `AppError::Conflict("Cannot delete membership type: {N} members still
+  use this type. Deactivate instead.")`. Usage counts
+  `members.membership_type_id = id`
+  (`src/repository/membership_type_repository.rs:243`).
+- `BasicTypeService::delete` for `BasicTypeKind::Event` —
+  `src/service/basic_type_service.rs:67-78`, via
+  `check_delete_unused_for_basic`
+  (`src/service/configurable_types.rs:53-67`). When usage > 0 it returns
+  `AppError::Conflict("Cannot delete event type: {N} events still use
+  this type. Deactivate instead.")`. Usage counts
+  `events.event_type_id = id`.
+- `BasicTypeService::delete` for `BasicTypeKind::Announcement` — same
+  function, message `"Cannot delete announcement type: {N} announcements
+  still use this type. Deactivate instead."`. Usage counts
+  `announcements.announcement_type_id = id`.
+
+### Why this is the gap (not the happy path)
+
+`tests/admin_types_audit_test.rs` already covers
+`delete_event_type_writes_audit_row_with_old_name`,
+`delete_announcement_type_writes_audit_row`, and
+`delete_membership_type_writes_audit_row` — but each creates a type and
+immediately deletes it with **no referencing rows**, so `count_usage`
+returns 0 and the `Conflict` branch is never hit. (The expense-type
+equivalents — `delete_category_with_existing_expenses_refuses` and
+`delete_account_with_existing_expenses_refuses` in
+`tests/expense_service_test.rs` — *are* covered; this gap is the
+membership/event/announcement type guards only.)
+
+## Acceptance criteria (against existing canon)
+
+This pins behavior already required by the **admin-types** capability,
+`openspec/specs/admin-types/spec.md`, Requirement **"Configurable
+types — membership, event, announcement"**:
+
+> #### Scenario: Deleting a type that is referenced by existing rows is rejected or soft-deleted
+> - **WHEN** an admin attempts to delete a membership type that is currently assigned to members
+> - **THEN** the operation SHALL either reject with a clear error or perform a soft-delete that hides the type without invalidating existing references
+
+The implementation chooses the "reject with a clear error" arm
+(`AppError::Conflict`). Acceptance: a referenced membership type, event
+type, and announcement type each fail to delete with `AppError::Conflict`
+whose message names the count and ends with `"Deactivate instead."`, and
+the type row SHALL still exist after the rejected delete.
+
+No production code changes. This is a test-only addition; no existing
+test is modified or deleted.

--- a/issues/tests-in-use-type-deletion-refusal/tasks.md
+++ b/issues/tests-in-use-type-deletion-refusal/tasks.md
@@ -1,0 +1,40 @@
+# Tasks
+
+Add three `#[tokio::test]` functions to
+`tests/admin_types_audit_test.rs`, reusing the existing `build_harness()`
+(which exposes `pool`, `event_svc`, `announcement_svc`, `membership_svc`,
+and a seeded member via `common::make_member`) and the `membership_form` /
+`basic_form` helpers. Seed the referencing row with raw SQL (the same
+direct-SQL pattern `tests/expiration_test.rs` uses), then call the
+service's `delete` and assert the `Conflict`.
+
+## 1. Membership-type in-use deletion is rejected
+- [ ] 1.1 `delete_membership_type_in_use_is_rejected` — with `build_harness()`,
+  create a membership type via `h.membership_svc.create(...)`; point a member
+  at it (`UPDATE members SET membership_type_id = ? WHERE id = ?` using the
+  harness member id, or insert a fresh member row referencing the type);
+  then assert `h.membership_svc.delete(type_id).await` returns
+  `Err(AppError::Conflict(msg))` where `msg.contains("Cannot delete membership type")`
+  and `msg.contains("Deactivate instead.")`, AND that
+  `h.membership_svc.get(type_id).await` still returns `Some(_)` (the row was
+  not deleted).
+
+## 2. Event-type in-use deletion is rejected
+- [ ] 2.1 `delete_event_type_in_use_is_rejected` — create an event type via
+  `h.event_svc.create(basic_form("Workshop"))`; insert one `events` row whose
+  `event_type_id` equals the new type id (raw SQL, minimal required columns);
+  then assert `h.event_svc.delete(type_id).await` returns
+  `Err(AppError::Conflict(msg))` where `msg.contains("Cannot delete event type")`
+  and `msg.contains("Deactivate instead.")`, AND `h.event_svc.get(type_id).await`
+  still returns `Some(_)`.
+
+## 3. Announcement-type in-use deletion is rejected
+- [ ] 3.1 `delete_announcement_type_in_use_is_rejected` — create an
+  announcement type via `h.announcement_svc.create(basic_form("Newsletter"))`;
+  insert one `announcements` row whose `announcement_type_id` equals the new
+  type id (raw SQL, minimal required columns); then assert
+  `h.announcement_svc.delete(type_id).await` returns
+  `Err(AppError::Conflict(msg))` where
+  `msg.contains("Cannot delete announcement type")` and
+  `msg.contains("Deactivate instead.")`, AND
+  `h.announcement_svc.get(type_id).await` still returns `Some(_)`.

--- a/openspec/changes/tests-dues-reminder-routing/proposal.md
+++ b/openspec/changes/tests-dues-reminder-routing/proposal.md
@@ -1,0 +1,55 @@
+## Why
+
+`Notifications::send_dues_reminders`
+(`src/service/billing_service/notifications.rs:272-473`) is the daily
+runner that emails members before their dues lapse. It has **zero test
+coverage** — it is referenced only by `src/jobs/billing_runner.rs:78`.
+`tests/auto_renew_alert_test.rs` and `tests/expiration_test.rs` cover the
+*charge* and *expiry* paths, never the *reminder* path.
+
+The function is non-trivial branching logic with four distinct outcomes
+(documented in its own doc comment at lines 259-271) and a per-cycle
+idempotency flag, none of which is asserted anywhere:
+
+1. **Manual billing** → "pay your dues" reminder.
+2. **Auto-renew + card valid at charge time + monthly period** → skip
+   silently (the charge will just happen), and deliberately do **not**
+   set `dues_reminder_sent_at` so the member stays eligible if their card
+   or mode changes mid-window.
+3. **Auto-renew + card valid + yearly period** → "we're about to
+   auto-charge you" renewal notice.
+4. **Auto-renew + card expired/missing by charge time** → the manual
+   reminder **plus a card-invalid callout** so the member knows
+   auto-charge won't save them.
+
+The highest-consequence branch is case 4: a member who believes
+auto-renew has them covered, whose card is actually dead, currently
+depends entirely on untested routing to be warned before they silently
+lapse to `Expired`.
+
+### Contract change (why spec lane, not issue lane)
+
+The reminder routing is **not described in any canonical spec**. The
+`recurring-billing` capability specifies the billing runner, dunning,
+idempotency, AdminAlert, and expiry sweep, but says nothing about which
+of the four reminder outcomes each member receives. Pinning this
+behavior with tests asserts a new capability invariant, so it lands in
+the spec lane: this change adds a `recurring-billing` requirement
+codifying the four-case routing and the case-2 "don't mark" idempotency
+nuance, and the tests assert it.
+
+## What Changes
+
+- Add a `recurring-billing` requirement specifying dues-reminder routing
+  by billing mode and card validity, plus the per-cycle idempotency flag.
+- Add `#[tokio::test]` cases to a new `tests/dues_reminder_test.rs`
+  exercising the four routing cases, the lifetime skip, and idempotency.
+
+## Impact
+
+- `tests/dues_reminder_test.rs` (new) — reminder routing tests built with
+  a recording `EmailSender`, reusing the member/card/settings seeding
+  patterns from `tests/auto_renew_alert_test.rs`.
+- `openspec/specs/recurring-billing/spec.md` (via this change's delta) —
+  one new requirement.
+- No production code change.

--- a/openspec/changes/tests-dues-reminder-routing/specs/recurring-billing/spec.md
+++ b/openspec/changes/tests-dues-reminder-routing/specs/recurring-billing/spec.md
@@ -1,0 +1,57 @@
+## ADDED Requirements
+
+### Requirement: Dues reminders route by billing mode and card validity
+
+`Notifications::send_dues_reminders` SHALL select reminder recipients as
+Active, non-`bypass_dues` members whose `dues_paid_until` falls within the
+configured reminder window (`membership.reminder_days_before`, clamped to
+1..=90, default 7) and whose `dues_reminder_sent_at` is unset. For each
+such member the runner SHALL choose exactly one of four outcomes based on
+billing mode, the default saved card's validity **at the charge date**
+(`dues_paid_until`), and the membership type's billing period:
+
+1. Manual billing → a "dues due soon" reminder with no card-invalid
+   callout.
+2. Auto-renew (CoterieManaged or StripeSubscription) with a card valid at
+   the charge date and a monthly period → no email, and `dues_reminder_sent_at`
+   SHALL NOT be set (so the member remains eligible if their card or mode
+   changes mid-window).
+3. Auto-renew with a card valid at the charge date and a yearly period →
+   a renewal notice announcing the upcoming auto-charge.
+4. Auto-renew with no card or a card that is not valid at the charge date →
+   the "dues due soon" reminder plus a card-invalid callout.
+
+Lifetime-period members SHALL be skipped (no email). Sending a reminder
+(cases 1, 3, 4) SHALL mark `dues_reminder_sent_at` so the same member is
+not reminded twice in one cycle; case 2 SHALL NOT mark it. The method
+SHALL return the count of emails actually sent.
+
+#### Scenario: Manual member receives a plain reminder
+
+- **WHEN** an Active manual-billing member's `dues_paid_until` is within the reminder window
+- **THEN** `send_dues_reminders` SHALL send one "dues due soon" reminder with no card-invalid callout and SHALL count it as sent
+
+#### Scenario: Auto-renew monthly member with a valid card is skipped and stays eligible
+
+- **WHEN** an auto-renew member on a monthly membership type has a default card valid at `dues_paid_until` and is within the window
+- **THEN** `send_dues_reminders` SHALL send no email AND SHALL leave `dues_reminder_sent_at` unset for that member
+
+#### Scenario: Auto-renew yearly member with a valid card gets a renewal notice
+
+- **WHEN** an auto-renew member on a yearly membership type has a default card valid at `dues_paid_until` and is within the window
+- **THEN** `send_dues_reminders` SHALL send a renewal-notice email (distinct from the "dues due soon" reminder) and SHALL count it as sent
+
+#### Scenario: Auto-renew member with an invalid or missing card gets a reminder with a card-invalid callout
+
+- **WHEN** an auto-renew member is within the window and has no default card, or a default card not valid at `dues_paid_until`
+- **THEN** `send_dues_reminders` SHALL send the "dues due soon" reminder including the card-invalid callout and SHALL count it as sent
+
+#### Scenario: Lifetime member in the window is skipped
+
+- **WHEN** a member on a lifetime-period membership type lands in the reminder window
+- **THEN** `send_dues_reminders` SHALL send no email for that member
+
+#### Scenario: Reminders are idempotent within a cycle
+
+- **WHEN** `send_dues_reminders` runs twice in succession without the reminder flag being reset, for a member who was reminded on the first run
+- **THEN** the second run SHALL send no further email to that member (the `dues_reminder_sent_at IS NULL` filter excludes them)

--- a/openspec/changes/tests-dues-reminder-routing/tasks.md
+++ b/openspec/changes/tests-dues-reminder-routing/tasks.md
@@ -1,0 +1,61 @@
+## 1. Test harness
+
+- [ ] 1.1 Add `tests/dues_reminder_test.rs`. Build a `Notifications` via
+  `Notifications::new(...)` wired with a recording `EmailSender`
+  (`Arc<Mutex<Vec<EmailMessage>>>`, returns `Ok(())`), plus the repos and
+  services (`SavedCardRepository`, `MembershipTypeService`, `SettingsService`,
+  member repo, `db_pool`, `base_url`) constructed exactly as in
+  `tests/auto_renew_alert_test.rs`. Reuse that file's `seed_default_card`
+  helper and member/membership-type seeding.
+- [ ] 1.2 Helper `set_dues_window(pool, member_id, days_from_now)` — set
+  `members.dues_paid_until` so the member falls inside the reminder window
+  (e.g. 3 days out), `status = 'Active'`, `bypass_dues = 0`,
+  `dues_reminder_sent_at = NULL`; set `membership.reminder_days_before` to a
+  value that includes it (e.g. 7) via direct SQL into `settings`.
+
+## 2. Case 1 — manual billing sends a plain reminder
+
+- [ ] 2.1 `manual_member_gets_plain_reminder` — seed an Active manual-billing
+  member in the window; run `send_dues_reminders()`; assert it returns `1`,
+  the recorder holds one message whose subject contains `"dues are due soon"`,
+  and the body does NOT contain the card-invalid callout.
+
+## 3. Case 2 — auto-renew + valid card + monthly is skipped and stays eligible
+
+- [ ] 3.1 `autorenew_monthly_valid_card_is_skipped` — seed a CoterieManaged
+  member on a monthly membership type with a default card valid past
+  `dues_paid_until`; run `send_dues_reminders()`; assert it returns `0` and
+  no message was recorded.
+- [ ] 3.2 `autorenew_monthly_skip_does_not_set_reminder_flag` — after 3.1's
+  run, assert `members.dues_reminder_sent_at` is still `NULL` for that member
+  (case 2 must leave them eligible for a later cycle).
+
+## 4. Case 3 — auto-renew + valid card + yearly gets a renewal notice
+
+- [ ] 4.1 `autorenew_yearly_valid_card_gets_renewal_notice` — seed a
+  CoterieManaged member on a yearly membership type with a valid default card;
+  run `send_dues_reminders()`; assert it returns `1` and the recorded
+  message's subject contains `"will renew"` (the renewal-notice subject), not
+  `"dues are due soon"`.
+
+## 5. Case 4 — auto-renew + invalid/missing card gets reminder with callout
+
+- [ ] 5.1 `autorenew_expired_card_gets_reminder_with_card_invalid_callout` —
+  seed a CoterieManaged member whose default card expires BEFORE
+  `dues_paid_until` (or seed no card); run `send_dues_reminders()`; assert it
+  returns `1`, the subject contains `"dues are due soon"`, and the body
+  contains the card-invalid callout (the `card_invalid = true` branch of the
+  `ReminderHtml`/`ReminderText` templates).
+
+## 6. Lifetime members are skipped
+
+- [ ] 6.1 `lifetime_member_is_skipped` — seed an Active member on a lifetime
+  membership type who somehow lands in the window; run
+  `send_dues_reminders()`; assert it returns `0` and no message recorded.
+
+## 7. Idempotency within a cycle
+
+- [ ] 7.1 `reminder_is_idempotent_within_cycle` — run `send_dues_reminders()`
+  for a manual member (Case 1), assert `1` sent, then run it again without
+  resetting `dues_reminder_sent_at` and assert the second run returns `0` and
+  records no additional message.

--- a/openspec/changes/tests-uncovered-stripe-webhook-handlers/proposal.md
+++ b/openspec/changes/tests-uncovered-stripe-webhook-handlers/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+Three production Stripe webhook handlers have **zero test coverage**. They
+are dispatched from `WebhookDispatcher::handle_webhook`
+(`src/payments/webhook_dispatcher/mod.rs:112-170`) but, unlike the
+payment-intent / charge / checkout / subscription-deleted / invoice
+handlers, they have no `dispatch_*` test seam and no test exercises them:
+
+- `handle_failed_payment` —
+  `src/payments/webhook_dispatcher/payment_intent.rs:13-28`. On
+  `payment_intent.payment_failed`, finds the payment by Stripe id and flips
+  `status` to `PaymentStatus::Failed`. When no payment matches, it is a
+  silent no-op. **Neither branch is tested.**
+- `handle_expired_session` —
+  `src/payments/webhook_dispatcher/checkout.rs:190-203`. On
+  `checkout.session.expired`, finds the payment by session id and flips
+  `status` to `Failed`. Unknown session → silent no-op. **Neither branch
+  is tested.**
+- `handle_subscription_updated` —
+  `src/payments/webhook_dispatcher/subscription.rs:80-108`. On
+  `customer.subscription.updated`, refreshes the member's stored
+  `subscription_id` via `set_billing_mode`. Unknown customer → silent
+  no-op. **Neither branch is tested.**
+
+These are real billing-correctness paths: a failed payment intent or an
+expired checkout that does *not* flip its row to `Failed` leaves a
+phantom `Pending` payment on the ledger, and a missed
+`subscription.updated` leaves a stale `subscription_id` so later invoice
+events can no longer be matched to the member.
+
+### Contract change (why spec lane, not issue lane)
+
+Closing this gap requires a **new test-seam contract**. The existing
+canon (`Requirement: Dispatcher exposes test seams …`) enumerates only
+`dispatch_payment_intent_succeeded`, `dispatch_charge_refunded`,
+`dispatch_subscription_deleted`, and `dispatch_checkout_session_completed`.
+There is no seam for these three handlers, and they are `pub(super)` —
+unreachable from an integration test without forging a signed webhook.
+This change adds `dispatch_failed_payment`, `dispatch_expired_session`,
+and `dispatch_subscription_updated` seams (under
+`#[cfg(any(test, feature = "test-utils"))]`, mirroring the existing
+convention) and adds a coverage requirement, exactly as the prior
+invoice-handler coverage change did for `dispatch_invoice_*`.
+
+## What Changes
+
+- Add three test-seam methods on `WebhookDispatcher` (cfg-gated) that
+  forward to the three handlers.
+- Add a coverage requirement to the `stripe-webhook` capability naming
+  the three handlers and the happy-path + unknown-target behaviors the
+  tests must assert.
+- Add six `#[tokio::test]` cases to `tests/stripe_webhook_test.rs`.
+
+## Impact
+
+- `src/payments/webhook_dispatcher/mod.rs` — three new cfg-gated
+  `dispatch_*` seam methods (no production behavior change).
+- `tests/stripe_webhook_test.rs` — six new test functions, reusing the
+  existing harness, payload builders, and dispatcher construction.
+- `openspec/specs/stripe-webhook/spec.md` (via this change's delta) — one
+  new requirement.

--- a/openspec/changes/tests-uncovered-stripe-webhook-handlers/specs/stripe-webhook/spec.md
+++ b/openspec/changes/tests-uncovered-stripe-webhook-handlers/specs/stripe-webhook/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Lifecycle webhook handlers have integration test coverage
+
+`tests/stripe_webhook_test.rs` SHALL include coverage for the three
+lifecycle webhook handlers that flip terminal payment state or refresh
+cached subscription data: `handle_failed_payment` (dispatched for
+`payment_intent.payment_failed`), `handle_expired_session` (dispatched for
+`checkout.session.expired`), and `handle_subscription_updated` (dispatched
+for `customer.subscription.updated`).
+
+To make these handlers reachable from integration tests without forging a
+signed webhook, `WebhookDispatcher` SHALL expose `dispatch_failed_payment`,
+`dispatch_expired_session`, and `dispatch_subscription_updated` methods
+under `#[cfg(any(test, feature = "test-utils"))]`, following the same
+convention as the existing `dispatch_*` seams. The tests SHALL exercise,
+for each handler, both the matching-target path (the expected DB state
+change occurs) and the unknown-target path (no panic, no spurious DB
+write).
+
+Adding handler changes for these event types in the future SHALL include
+updates to the relevant test, not a "trust me" commit.
+
+#### Scenario: payment_intent.payment_failed flips the matching payment to Failed
+
+- **WHEN** `dispatch_failed_payment` is called with the Stripe payment id of an existing `Pending` payment whose `external_id` is `StripeRef::PaymentIntent`
+- **THEN** the test SHALL assert the payment row's `status` becomes `PaymentStatus::Failed`
+
+#### Scenario: payment_intent.payment_failed for an unknown payment id is a no-op
+
+- **WHEN** `dispatch_failed_payment` is called with a Stripe payment id that matches no payment row
+- **THEN** the test SHALL assert the call returns `Ok(())` with no panic and no payment row status change
+
+#### Scenario: checkout.session.expired flips the matching payment to Failed
+
+- **WHEN** `dispatch_expired_session` is called with a `CheckoutSession` whose id matches an existing `Pending` payment whose `external_id` is `StripeRef::CheckoutSession`
+- **THEN** the test SHALL assert the payment row's `status` becomes `PaymentStatus::Failed`
+
+#### Scenario: checkout.session.expired for an unknown session id is a no-op
+
+- **WHEN** `dispatch_expired_session` is called with a `CheckoutSession` whose id matches no payment row
+- **THEN** the test SHALL assert the call returns `Ok(())` with no panic and no payment row status change
+
+#### Scenario: customer.subscription.updated refreshes the stored subscription id
+
+- **WHEN** `dispatch_subscription_updated` is called with a `Subscription` whose customer id matches a known member and whose subscription id differs from the member's stored value
+- **THEN** the test SHALL assert the member row's stored `subscription_id` is updated to the new value
+
+#### Scenario: customer.subscription.updated for an unknown customer is a no-op
+
+- **WHEN** `dispatch_subscription_updated` is called with a `Subscription` whose customer id maps to no member
+- **THEN** the test SHALL assert the call returns `Ok(())` with no panic and no member row mutation

--- a/openspec/changes/tests-uncovered-stripe-webhook-handlers/tasks.md
+++ b/openspec/changes/tests-uncovered-stripe-webhook-handlers/tasks.md
@@ -1,0 +1,44 @@
+## 1. Add cfg-gated test seams for the three handlers
+
+- [ ] 1.1 In `src/payments/webhook_dispatcher/mod.rs`, under the existing
+  `#[cfg(any(test, feature = "test-utils"))] impl WebhookDispatcher` block,
+  add `pub async fn dispatch_failed_payment(&self, stripe_payment_id: String) -> Result<()>`
+  forwarding to `self.handle_failed_payment(stripe_payment_id)`.
+- [ ] 1.2 Add `pub async fn dispatch_expired_session(&self, session: CheckoutSession) -> Result<()>`
+  forwarding to `self.handle_expired_session(session)`.
+- [ ] 1.3 Add `pub async fn dispatch_subscription_updated(&self, subscription: stripe::Subscription) -> Result<()>`
+  forwarding to `self.handle_subscription_updated(subscription)`.
+
+## 2. Tests for handle_failed_payment
+
+- [ ] 2.1 `failed_payment_flips_matching_payment_to_failed` — seed a
+  `Pending` payment whose `external_id` is `StripeRef::PaymentIntent(pi_id)`;
+  call `dispatch.dispatch_failed_payment(pi_id.to_string())`; assert the
+  payment row's `status` is now `PaymentStatus::Failed`.
+- [ ] 2.2 `failed_payment_for_unknown_id_is_noop` — with no matching payment,
+  call `dispatch_failed_payment("pi_does_not_exist".into())`; assert it
+  returns `Ok(())`, no panic, and no payment row changes status.
+
+## 3. Tests for handle_expired_session
+
+- [ ] 3.1 `expired_session_flips_pending_payment_to_failed` — seed a
+  `Pending` payment whose `external_id` is `StripeRef::CheckoutSession(cs_id)`;
+  build a `CheckoutSession` with `id = cs_id` (reuse the JSON-deserialization
+  pattern already in `tests/stripe_webhook_test.rs`); call
+  `dispatch.dispatch_expired_session(session)`; assert the payment row's
+  `status` is now `Failed`.
+- [ ] 3.2 `expired_session_for_unknown_session_is_noop` — dispatch a
+  `CheckoutSession` whose id matches no payment; assert `Ok(())`, no panic,
+  and no payment row changes status.
+
+## 4. Tests for handle_subscription_updated
+
+- [ ] 4.1 `subscription_updated_refreshes_stored_subscription_id` — seed a
+  member with a known `stripe_customer_id` and an old
+  `stripe_subscription_id`; build a `stripe::Subscription` with that customer
+  and a NEW subscription id; call
+  `dispatch.dispatch_subscription_updated(subscription)`; assert the member
+  row's stored subscription id now equals the new id.
+- [ ] 4.2 `subscription_updated_for_unknown_customer_is_noop` — dispatch a
+  `Subscription` whose customer maps to no member; assert `Ok(())`, no panic,
+  and no member row is mutated.


### PR DESCRIPTION
This PR ships audit-produced proposals only — no implementer changes this iteration.

## Audit-produced proposals

- audit: missing-tests proposals (4 unit(s))

Each `audit: <type>` commit creates new `openspec/changes/<prefix>-*` directories that the next polling iteration will pick up via `list_pending` and route to the implementer.
