### PR TITLE
audit-only: 3 proposal(s) from security-bug

### DIFF
--- a/issues/fix-webhook-completes-payment-before-extending-dues/issue.md
+++ b/issues/fix-webhook-completes-payment-before-extending-dues/issue.md
@@ -1,0 +1,111 @@
+# Webhook flips payment to Completed before extending dues — a transient extend failure strands the member, and Stripe's retry can't recover it
+
+## Summary
+
+Both successful-payment webhook handlers flip the Payment row
+`Pending → Completed` **before** extending the member's dues. If the
+dues-extension step then fails transiently (DB hiccup, lock timeout, a
+slow membership-type lookup), the handler returns `Err`, the dispatcher
+releases the idempotency claim so Stripe retries — but the row is now
+`Completed`, so on retry `complete_pending_payment` returns `false` and
+the handler short-circuits at the `if !won_flip { return Ok(()) }`
+guard. The dues extension **never re-runs**.
+
+Net result: the member was charged, the Payment row shows `Completed`,
+but their `dues_paid_until` was never advanced — and the retry mechanism
+the dispatcher relies on is defeated for this case. No `AdminAlert`
+fires (that path only triggers when the membership-type *slug* can't be
+resolved, not when the extend step itself errors). The member silently
+expires later despite having paid.
+
+This is a behavior-preserving correction: the canonical stripe-webhook
+contract already requires that a transient handler failure be
+*recoverable on Stripe retry*, and that dues advance *exactly once*. The
+current ordering violates both. No observable contract changes — hence
+the issue lane (no `specs/` delta).
+
+## Source location
+
+`src/payments/webhook_dispatcher/checkout.rs:47-58` and `:148-153`
+(`handle_successful_payment`):
+
+```rust
+let won_flip = self
+    .payment_repo
+    .complete_pending_payment(payment.id, &pi_for_row)   // <-- flip FIRST
+    .await?;
+if !won_flip {
+    // ... retry short-circuits here ...
+    return Ok(());
+}
+// ... later, the step that can fail ...
+billing_service
+    .auto_renew
+    .extend_member_dues_by_slug(payment.id, member_id, slug)   // <-- extend SECOND
+    .await?;
+```
+
+`src/payments/webhook_dispatcher/payment_intent.rs:128-139` and
+`:191-194` (`handle_payment_intent_succeeded`) — identical ordering:
+`complete_pending_payment` (flip) at 128, early-return on `!won_flip` at
+132-139, `extend_member_dues_by_slug` at 191-194.
+
+Supporting facts (verified):
+
+- `PaymentRepository::complete_pending_payment`
+  (`src/repository/payment_repository.rs:397-415`) runs
+  `UPDATE payments SET status='Completed' ... WHERE id=? AND status='Pending'`
+  and returns `true` only when one row was flipped — so it returns
+  `false` forever after the first flip.
+- `AutoRenew::extend_member_dues` →
+  `PaymentRepository::extend_dues_for_payment_atomic(payment_id, ...)`
+  (`src/service/billing_service/auto_renew.rs:843-879`) is an **atomic,
+  idempotent per-`payment_id` claim** (`UPDATE ... WHERE
+  dues_extended_at IS NULL`). It cannot double-extend across retries.
+  Because it is idempotent, it is safe to run it *before* the flip and
+  to let Stripe's retry re-run it until it succeeds.
+- The dispatcher's rollback (`webhook_dispatcher/mod.rs:181-199`)
+  `release`s the idempotency claim on handler error so Stripe retries —
+  which is the recovery path that the already-flipped row defeats.
+
+The fix is to make the irreversible `Completed` flip the **last**
+must-succeed step in the membership path: extend dues first (idempotent,
+retry-safe), then flip. A transient extend failure then leaves the row
+`Pending`, so the next Stripe retry re-enters and recovers it, and the
+Pending-payments admin review can also see it. The donation path (whose
+only post-work *is* the flip) and the slug-unresolvable path (which
+deliberately gives up and alerts an operator) keep the flip as their
+terminal step.
+
+## Why this is harmful (trigger and impact)
+
+- **Trigger:** any `checkout.session.completed` or
+  `payment_intent.succeeded` for a membership payment where the row flip
+  succeeds but the subsequent dues-extension (or the membership-type
+  lookup it performs) errors transiently. Transient DB errors under load
+  are routine; this is not an exotic input.
+- **Impact:** money taken, Payment row `Completed`, dues not extended,
+  no alert, and the very Stripe-retry mechanism meant to recover the
+  failure is turned into a permanent no-op. The member's access lapses
+  later with no record that anything went wrong.
+
+## Acceptance criteria (against the EXISTING specification)
+
+These restate guarantees already in canon; the fix makes the
+checkout/PaymentIntent handlers conform to them. No spec delta.
+
+- Conforms to **stripe-webhook → "Failed processing releases the claim
+  for retry" / scenario "Transient handler failure is retried on next
+  delivery"**: when the dues-extension step fails for a membership
+  payment, a subsequent Stripe retry of the same event SHALL extend the
+  member's dues. The payment row SHALL NOT be left `Completed` with dues
+  unextended; on a transient extend failure the row SHALL remain
+  `Pending` so the retry can recover it.
+- Conforms to **stripe-webhook → "Event processing is idempotent via
+  atomic claim"** (and the invoice analog "invoice.paid is idempotent
+  under Stripe retry — dues advance exactly once"): across the original
+  delivery plus any retries, the member's `dues_paid_until` SHALL advance
+  **exactly once** for a single payment — never twice.
+- The donation path and the membership-type-slug-unresolvable path
+  retain their current observable behavior (donation: flip + log, no
+  dues work; unresolvable slug: flip + single `AdminAlert`).

--- a/issues/fix-webhook-completes-payment-before-extending-dues/tasks.md
+++ b/issues/fix-webhook-completes-payment-before-extending-dues/tasks.md
@@ -1,0 +1,73 @@
+# Tasks
+
+## 1. Reorder the checkout success handler so dues extend before the Completed flip
+
+- [ ] 1.1 In `src/payments/webhook_dispatcher/checkout.rs::handle_successful_payment`,
+  move the `payment_type_str` resolution (currently after the flip) to
+  before any call to `complete_pending_payment` — it only reads
+  `session.metadata` and `payment.kind`, so it does not depend on the flip.
+- [ ] 1.2 For the **donation** branch, keep the flip as the terminal step:
+  call `complete_pending_payment(payment.id, &pi_for_row)`; if it returns
+  `false`, return `Ok(())` (a retry/loser of the race); otherwise log the
+  donation and return `Ok(())`. (Donations have no dues post-work, so
+  flip-first is correct and cannot strand anything.)
+- [ ] 1.3 For the **membership** branch with a resolvable slug, call
+  `billing_service.auto_renew.extend_member_dues_by_slug(payment.id,
+  member_id, slug).await?` **before** `complete_pending_payment`. Then
+  flip: `let won_flip = self.payment_repo.complete_pending_payment(
+  payment.id, &pi_for_row).await?;`. Run the best-effort
+  `reschedule_after_payment` only when `won_flip` is `true` (so only the
+  caller that actually flipped reschedules — avoids double cancel/queue
+  churn on the sync/webhook race). Keep `reschedule_after_payment`'s
+  error soft-failed (log, do not propagate), as today.
+- [ ] 1.4 For the **slug-unresolvable** branch, keep current behavior:
+  flip to `Completed` and dispatch the single `AdminAlert`
+  ("Checkout paid but dues not extended"). This path intentionally gives
+  up on automatic extension; the flip stays terminal here.
+- [ ] 1.5 Confirm that a transient error returned by
+  `extend_member_dues_by_slug` now propagates (`?`) *before* the flip, so
+  the row is left `Pending` and the dispatcher's claim release
+  (`webhook_dispatcher/mod.rs`) lets Stripe's retry re-enter.
+
+## 2. Reorder the PaymentIntent success handler the same way
+
+- [ ] 2.1 In `src/payments/webhook_dispatcher/payment_intent.rs::handle_payment_intent_succeeded`,
+  keep the existing metadata/member/amount cross-checks (lines ~53-125)
+  ahead of any mutation — they must stay before the flip.
+- [ ] 2.2 For the **non-membership** (donation/other) case, keep the flip
+  terminal: `complete_pending_payment`; if `false`, return `Ok(())`;
+  otherwise return `Ok(())` (no dues work).
+- [ ] 2.3 For the **membership** case, resolve `member_id`, the member,
+  and the slug as today, then call `extend_member_dues_by_slug(payment_id,
+  member_id, &slug).await?` **before** `complete_pending_payment`. Flip
+  after a successful extend, and run the best-effort
+  `reschedule_after_payment` only when the flip returned `true`.
+- [ ] 2.4 Preserve the existing early-return no-ops (missing
+  `payment_id` metadata, malformed UUID, unknown local payment, missing
+  member, unresolvable membership type) — those must still return
+  `Ok(())` without flipping.
+
+## 3. Regression tests
+
+- [ ] 3.1 Add a test to `tests/stripe_webhook_test.rs` (using the
+  `dispatch_checkout_session_completed` seam) named e.g.
+  `checkout_completed_leaves_payment_pending_when_dues_extend_fails`:
+  insert a `Pending` membership Payment row, dispatch a
+  `CheckoutSession` whose metadata sets `payment_type=membership` and
+  `membership_type_slug` to a slug **not present** in the membership-type
+  registry (forces `extend_member_dues_by_slug` to return
+  `AppError::NotFound`). Assert the dispatch returns `Err` AND the
+  Payment row's status is still `Pending` (NOT `Completed`).
+- [ ] 3.2 Extend that test to prove recovery: create the membership type
+  for that slug, dispatch the same event again, and assert the Payment
+  row is now `Completed` AND the member's `dues_paid_until` advanced by
+  exactly one billing period (extend ran exactly once).
+- [ ] 3.3 Add the analogous test for
+  `dispatch_payment_intent_succeeded` in `tests/stripe_webhook_test.rs`:
+  a membership PaymentIntent whose member's membership type is missing at
+  first dispatch leaves the row `Pending`; once resolvable, a retry
+  completes it and advances dues exactly once.
+- [ ] 3.4 Keep/confirm an idempotency assertion: dispatching a
+  successful membership event twice (both deliveries succeeding) advances
+  `dues_paid_until` exactly once, mirroring the existing
+  "invoice.paid is idempotent under Stripe retry" coverage.

--- a/openspec/changes/secure-bound-signup-text-fields/proposal.md
+++ b/openspec/changes/secure-bound-signup-text-fields/proposal.md
@@ -1,0 +1,57 @@
+# secure-bound-signup-text-fields
+
+## Why
+
+`POST /public/signup` (`src/api/handlers/public.rs::signup`,
+lines 97-131) is an **unauthenticated** endpoint that persists three
+free-text fields — `email`, `username`, `full_name` — with essentially
+no input bounding. The only validation is:
+
+```rust
+if !request.email.contains('@') {
+    return Err(AppError::BadRequest("Invalid email format".to_string()));
+}
+```
+
+`username` and `full_name` get **no** length or non-empty check, and
+`email` gets **no** length cap, before `member_repo.create(...)` writes
+the row. The sibling public-donate handler in the same file
+(`src/api/handlers/public.rs:608-621`) already bounds the equivalent
+fields — `email.len() <= 254`, `name.len() <= 200`, and rejects empty
+values — so the signup path is the inconsistent one.
+
+- **Trigger:** unauthenticated POST to `/public/signup` (gated only by
+  the bot challenge; deliberately **not** behind `money_limiter` per the
+  public-signup spec) with megabyte-sized `email` / `username` /
+  `full_name` values.
+- **Harm:** unbounded row growth from unauthenticated input — a
+  storage-abuse / resource-exhaustion vector. These values are also
+  later emitted verbatim in the admin CSV export.
+
+This adds a new validation invariant at the signup HTTP boundary —
+oversized/empty fields previously **accepted** (member created) are now
+**rejected** (`400`) — so it changes an observable contract and lands in
+the spec lane.
+
+## What Changes
+
+- In `signup`, before creating the member, trim and bound the text
+  fields, mirroring the donate handler's caps:
+  - `email`: non-empty, contains `@`, `len() <= 254`.
+  - `full_name`: non-empty after trim, `len() <= 200`.
+  - `username`: non-empty after trim, `len() <= 100`.
+  Reject with `AppError::BadRequest` and a clear message on violation.
+- No change to the existing bot-challenge gate, membership-type
+  resolution, or the UNIQUE-violation handling.
+
+## Impact
+
+- Spec: `public-signup` — `ADDED` requirement "Signup bounds and
+  validates its input fields".
+- Code: `src/api/handlers/public.rs` (`signup`).
+- Tests: handler-level tests asserting oversized/empty fields are
+  rejected with `400`.
+- No database schema, wire-format, or API-shape changes. The specific
+  caps (254 / 200 / 100) match the existing donate handler and are
+  implementation guidance; the binding invariant is that the signup
+  text fields are non-empty and length-bounded.

--- a/openspec/changes/secure-bound-signup-text-fields/specs/public-signup/spec.md
+++ b/openspec/changes/secure-bound-signup-text-fields/specs/public-signup/spec.md
@@ -1,0 +1,28 @@
+# public-signup Specification
+
+## ADDED Requirements
+
+### Requirement: Signup bounds and validates its input fields
+
+`POST /public/signup` SHALL validate and length-bound its free-text input fields before creating a member, so an unauthenticated caller cannot persist unbounded data. The handler SHALL reject the request with `400` (`AppError::BadRequest`) when any of the following fails (checked against the trimmed value):
+
+- `email`: non-empty, contains `@`, and at most 254 characters.
+- `full_name`: non-empty and at most 200 characters.
+- `username`: non-empty and at most 100 characters.
+
+These bounds match the existing public-donate handler so the two unauthenticated entry points are consistent. Validation SHALL run after the bot-challenge gate and before any member is persisted.
+
+#### Scenario: Over-long field is rejected
+
+- **WHEN** a signup request supplies an `email` longer than 254 characters, a `full_name` longer than 200 characters, or a `username` longer than 100 characters
+- **THEN** the handler SHALL return `400` and SHALL NOT create a member
+
+#### Scenario: Empty required field is rejected
+
+- **WHEN** a signup request supplies an empty or whitespace-only `username` or `full_name`
+- **THEN** the handler SHALL return `400` and SHALL NOT create a member
+
+#### Scenario: Valid bounded signup succeeds
+
+- **WHEN** a signup request supplies a valid `@`-bearing email within 254 characters and non-empty `username`/`full_name` within their bounds, with a verified bot-challenge token
+- **THEN** a `Pending` member SHALL be created (the bounds do not reject normal-length input)

--- a/openspec/changes/secure-bound-signup-text-fields/tasks.md
+++ b/openspec/changes/secure-bound-signup-text-fields/tasks.md
@@ -1,0 +1,27 @@
+# Tasks
+
+## 1. Bound and validate signup text fields
+
+- [ ] 1.1 In `src/api/handlers/public.rs::signup`, after the
+  bot-challenge gate and before `member_repo.create`, trim `email`,
+  `username`, and `full_name` and validate:
+  - `email`: non-empty, contains `@`, `len() <= 254` — else
+    `AppError::BadRequest`.
+  - `full_name`: non-empty after trim, `len() <= 200` — else
+    `AppError::BadRequest`.
+  - `username`: non-empty after trim, `len() <= 100` — else
+    `AppError::BadRequest`.
+  Use the trimmed values when building `CreateMemberRequest`.
+- [ ] 1.2 Keep the existing bot-challenge check, password validation,
+  membership-type-slug resolution, and UNIQUE-violation mapping
+  unchanged and in their current order.
+
+## 2. Tests
+
+- [ ] 2.1 Add handler/integration tests for `signup` asserting `400`
+  (`AppError::BadRequest`) when `full_name` exceeds 200 chars, when
+  `username` exceeds 100 chars, when `email` exceeds 254 chars, and when
+  `username` or `full_name` is empty/whitespace-only.
+- [ ] 2.2 Add a test asserting a normal-length, valid signup still
+  succeeds (member created) — guarding against the bounds being too
+  tight.

--- a/openspec/changes/secure-cap-password-length/proposal.md
+++ b/openspec/changes/secure-cap-password-length/proposal.md
@@ -1,0 +1,64 @@
+# secure-cap-password-length
+
+## Why
+
+`crate::auth::validate_password` (`src/auth/mod.rs:134-148`) enforces a
+**minimum** length of 10 characters and three character-class rules, but
+no **maximum** length:
+
+```rust
+pub fn validate_password(password: &str) -> std::result::Result<(), &'static str> {
+    if password.len() < 10 { ... }
+    // ... upper / lower / digit checks ...
+    Ok(())   // <-- no upper bound
+}
+```
+
+It is the documented single source of truth for password rules and is
+invoked on every set-password path before the result is Argon2-hashed —
+including the **unauthenticated** signup (`src/api/handlers/public.rs:103`)
+and password-reset (`src/web/templates/reset.rs`) flows, plus in-portal
+change and first-run setup.
+
+Argon2's input is absorbed by a Blake2b pass whose cost scales with the
+password length, on top of the fixed memory-hard work. With no upper
+bound, the only ceiling is axum's default request-body limit, so a caller
+can submit a multi-hundred-KB "password" and force the server to hash it.
+Per the public-signup spec, signup is deliberately **not** behind the
+`money_limiter` (the bot challenge is its only abuse gate), so a
+solved-challenge or `provider=disabled` deployment lets an attacker
+amplify CPU per request — a denial-of-service vector against an
+unauthenticated endpoint.
+
+- **Trigger:** unauthenticated POST to `/public/signup` (or
+  `/reset-password`) with an oversized `password` field.
+- **Harm:** CPU exhaustion via Argon2 amplification on an unauthenticated
+  endpoint (resource-exhaustion DoS).
+
+This changes an observable contract — a password longer than the new
+bound, previously **accepted** (`201`/redirect, member created or
+password reset), is now **rejected** (`400`/inline error) at the
+signup/reset/change boundary — so it lands in the spec lane as a
+`MODIFIED` of the existing password-complexity requirement rather than an
+issue. Capping password length (commonly 64–128 chars) is standard
+hardening (OWASP) precisely to neutralize this DoS.
+
+## What Changes
+
+- Add a maximum-length check to `validate_password` so it rejects
+  passwords longer than an upper bound (128 characters), returning a
+  clear error message. Because every set-password path funnels through
+  this one validator, the single guard covers signup, reset, in-portal
+  change, and setup with no per-call-site edits.
+- The minimum length and character-class rules are unchanged.
+
+## Impact
+
+- Spec: `password-management` — `MODIFIED` requirement "Password
+  complexity is validated at change/reset/signup" (adds the upper-bound
+  rule + a rejection scenario).
+- Code: `src/auth/mod.rs` (`validate_password`).
+- Tests: unit test for the new bound in `src/auth/mod.rs`.
+- No database, wire-format, or API-shape changes. The 128-character cap
+  is generous for passphrases; the exact number is implementation
+  guidance, the binding invariant is that an upper bound exists.

--- a/openspec/changes/secure-cap-password-length/specs/password-management/spec.md
+++ b/openspec/changes/secure-cap-password-length/specs/password-management/spec.md
@@ -1,0 +1,22 @@
+# password-management Specification
+
+## MODIFIED Requirements
+
+### Requirement: Password complexity is validated at change/reset/signup
+
+`crate::auth::validate_password` SHALL be invoked before hashing on every code path that sets a password (signup, in-portal change, reset). The validator's rules are the single source of truth for complexity. The validator SHALL enforce both a minimum length AND a maximum length: a password longer than the upper bound (128 characters) SHALL be rejected before it is Argon2-hashed, so an unauthenticated caller cannot force expensive hashing of an oversized input (an Argon2 CPU-amplification denial of service).
+
+#### Scenario: Weak password rejected at change
+
+- **WHEN** a member submits the password-change form with a password failing complexity rules
+- **THEN** the handler SHALL render an inline error and SHALL NOT update the hash
+
+#### Scenario: Weak password rejected at reset
+
+- **WHEN** a reset-token consumer submits a password failing complexity rules
+- **THEN** the handler SHALL reject the submission and the token SHALL NOT be marked consumed
+
+#### Scenario: Over-long password rejected before hashing
+
+- **WHEN** a password exceeding the maximum length (128 characters) is submitted on any set-password path (signup, reset, in-portal change, setup)
+- **THEN** `validate_password` SHALL return an error and the password SHALL NOT be Argon2-hashed or persisted

--- a/openspec/changes/secure-cap-password-length/tasks.md
+++ b/openspec/changes/secure-cap-password-length/tasks.md
@@ -1,0 +1,19 @@
+# Tasks
+
+## 1. Add a maximum-length bound to the password validator
+
+- [ ] 1.1 In `src/auth/mod.rs::validate_password`, add a check that
+  rejects passwords longer than 128 characters, returning
+  `Err("Password must be at most 128 characters")`. Place it alongside
+  the existing minimum-length check; leave the minimum and the
+  upper/lower/digit rules unchanged.
+
+## 2. Tests
+
+- [ ] 2.1 Add a unit test in `src/auth/mod.rs` asserting
+  `validate_password` returns `Err` for a password of length 129 (e.g. a
+  129-char string that otherwise satisfies the complexity rules) and
+  returns `Ok` for a valid 128-char password.
+- [ ] 2.2 Add a unit test asserting a multi-kilobyte password (e.g.
+  10_000 chars) is rejected by `validate_password`, documenting the
+  Argon2 DoS guard.


### PR DESCRIPTION
This PR ships audit-produced proposals only — no implementer changes this iteration.

## Audit-produced proposals

- audit: security-bug proposals (3 unit(s))

Each `audit: <type>` commit creates new `openspec/changes/<prefix>-*` directories that the next polling iteration will pick up via `list_pending` and route to the implementer.
