### PR TITLE
spec-revision: `secure-cap-password-length`

### DIFF
--- a/openspec/changes/secure-cap-password-length/specs/password-management/spec.md
+++ b/openspec/changes/secure-cap-password-length/specs/password-management/spec.md
@@ -4,7 +4,7 @@
 
 ### Requirement: Password complexity is validated at change/reset/signup
 
-`crate::auth::validate_password` SHALL be invoked before hashing on every code path that sets a password (signup, in-portal change, reset). The validator's rules are the single source of truth for complexity. The validator SHALL enforce both a minimum length AND a maximum length: a password longer than the upper bound (128 characters) SHALL be rejected before it is Argon2-hashed, so an unauthenticated caller cannot force expensive hashing of an oversized input (an Argon2 CPU-amplification denial of service).
+`crate::auth::validate_password` SHALL be invoked before hashing on every code path that sets a password (signup, in-portal change, reset, setup). The validator's rules are the single source of truth for complexity. The validator SHALL enforce both a minimum length AND a maximum length: a password longer than the upper bound (128 characters) SHALL be rejected before it is Argon2-hashed, so an unauthenticated caller cannot force expensive hashing of an oversized input (an Argon2 CPU-amplification denial of service).
 
 #### Scenario: Weak password rejected at change
 


### PR DESCRIPTION
This PR revises the spec deltas of change `secure-cap-password-length` in `git@github.com:IndustriousKraken/coterie.git` to resolve a `[in]` / `[canon]` contradiction flagged at implement time.

The revision was directed by an operator in the change's spec-revision thread AND re-verified against the `[in]` and `[canon]` gates before this PR opened. Review the spec deltas; merging applies the revision. No code or tasks.md changes are included.
