### PR TITLE
agent-q changes: 1 commit(s) across other

### DIFF
--- a/issues/archive/2026-07-14-event-status-compares-wall-clock-to-utc-now.md
+++ b/issues/archive/2026-07-14-event-status-compares-wall-clock-to-utc-now.md
@@ -144,24 +144,24 @@ time as a regression.
 
 ### 1. Derive the instant before comparing to `now`
 
-- [ ] 1.1 `src/web/portal/admin/events/single.rs:141-142` — change
+- [x] 1.1 `src/web/portal/admin/events/single.rs:141-142` — change
   `e.start_time > now` → `e.start_utc() > now` and `e.start_time <= now` →
   `e.start_utc() <= now` in the `time_filter` match.
-- [ ] 1.2 `src/web/portal/admin/events/single.rs:186` — `is_past: e.start_time <= now`
+- [x] 1.2 `src/web/portal/admin/events/single.rs:186` — `is_past: e.start_time <= now`
   → `is_past: e.start_utc() <= now`.
-- [ ] 1.3 `src/web/portal/admin/events/single.rs:311` —
+- [x] 1.3 `src/web/portal/admin/events/single.rs:311` —
   `is_past: event.start_time <= now` → `is_past: event.start_utc() <= now`.
-- [ ] 1.4 `src/web/portal/admin/events/occurrences.rs:60` —
+- [x] 1.4 `src/web/portal/admin/events/occurrences.rs:60` —
   `is_past: event.start_time <= now` → `is_past: event.start_utc() <= now`.
-- [ ] 1.5 `src/web/portal/events.rs:84` — `let is_past = event.start_time < now`
+- [x] 1.5 `src/web/portal/events.rs:84` — `let is_past = event.start_time < now`
   → `let is_past = event.start_utc() < now`.
-- [ ] 1.6 Do NOT alter any `.format(...)` render line or `single.rs:153` sort.
+- [x] 1.6 Do NOT alter any `.format(...)` render line or `single.rs:153` sort.
   Confirm `Event::start_utc()` is in scope for each `Event` value edited (it is
   an inherent method on `Event`).
 
 ### 2. Regression test
 
-- [ ] 2.1 Add a unit test near the `event-timezone` tests
+- [x] 2.1 Add a unit test near the `event-timezone` tests
   (`src/domain/event.rs`) or a portal test that builds an `Event` with a 7 PM
   `America/New_York` wall-clock and asserts: at a `now` that is after `19:00Z`
   but before the derived `start_utc()` (i.e. `00:00Z` next day),
@@ -170,6 +170,6 @@ time as a regression.
 
 ### 3. Verify
 
-- [ ] 3.1 `cargo test` — full suite green, including the new test and the
+- [x] 3.1 `cargo test` — full suite green, including the new test and the
   existing `event-timezone` / reminder suites.
-- [ ] 3.2 `cargo clippy` on the touched files — no new warnings.
+- [x] 3.2 `cargo clippy` on the touched files — no new warnings.

--- a/src/domain/event.rs
+++ b/src/domain/event.rs
@@ -276,6 +276,26 @@ mod tz_tests {
         assert_eq!(utc.to_rfc3339(), "2026-03-08T07:30:00+00:00");
     }
 
+    // Past/upcoming status must compare the DERIVED instant to `now`, not
+    // the raw wall-clock. A 7 PM EST event (19:00 wall-clock, 00:00Z next
+    // day) at a `now` after 19:00Z but before the true start is still
+    // upcoming; comparing the raw wall-clock would wrongly call it past.
+    #[test]
+    fn past_status_uses_derived_instant_not_wallclock() {
+        let e = event_at(wall(2026, 1, 23, 19, 0), "America/New_York");
+        // 19:30Z on the event day: after the raw wall-clock (19:00Z) but
+        // ~4.5h before the true start (00:00Z the 24th, EST is UTC-5).
+        let now = Utc.with_ymd_and_hms(2026, 1, 23, 19, 30, 0).unwrap();
+        assert_eq!(e.start_utc().to_rfc3339(), "2026-01-24T00:00:00+00:00");
+        // Correct: derived instant is still in the future → upcoming.
+        assert!(e.start_utc() > now, "derived instant should be upcoming");
+        // The bug: raw wall-clock would flip it to past ~4.5h early.
+        assert!(
+            e.start_time <= now,
+            "raw wall-clock (19:00Z) mis-reads as past against 19:30Z now"
+        );
+    }
+
     // DST overlap (fall-back): 01:30 on 2026-11-01 happens twice in
     // America/New_York. The defined rule picks the earliest (EDT) instant.
     #[test]

--- a/src/web/portal/admin/events/occurrences.rs
+++ b/src/web/portal/admin/events/occurrences.rs
@@ -57,7 +57,7 @@ impl OccurrenceRowInfo {
             title: event.title.clone(),
             start_time: event.start_time.format("%b %d, %Y %H:%M").to_string(),
             location: event.location.clone(),
-            is_past: event.start_time <= now,
+            is_past: event.start_utc() <= now,
             state: "active",
             reason: None,
         }

--- a/src/web/portal/admin/events/single.rs
+++ b/src/web/portal/admin/events/single.rs
@@ -138,8 +138,8 @@ pub async fn admin_events_page(
                 return false;
             }
             match time_filter.as_str() {
-                "upcoming" => e.start_time > now,
-                "past" => e.start_time <= now,
+                "upcoming" => e.start_utc() > now,
+                "past" => e.start_utc() <= now,
                 _ => true,
             }
         })
@@ -169,6 +169,7 @@ pub async fn admin_events_page(
         .take(per_page as usize)
     {
         let attendee_count = event_repo.get_attendee_count(e.id).await.unwrap_or(0);
+        let is_past = e.start_utc() <= now;
 
         paginated_events.push(AdminEventInfo {
             id: e.id.to_string(),
@@ -183,7 +184,7 @@ pub async fn admin_events_page(
             attendee_count,
             max_attendees: e.max_attendees,
             rsvp_required: e.rsvp_required,
-            is_past: e.start_time <= now,
+            is_past,
         });
     }
 
@@ -288,6 +289,7 @@ pub async fn admin_event_detail_page(
     let attendee_count = event_repo.get_attendee_count(event.id).await.unwrap_or(0);
 
     let now = chrono::Utc::now();
+    let is_past = event.start_utc() <= now;
 
     let detail = AdminEventDetail {
         id: event.id.to_string(),
@@ -308,7 +310,7 @@ pub async fn admin_event_detail_page(
         rsvp_required: event.rsvp_required,
         image_url: event.image_url,
         attendee_count,
-        is_past: event.start_time <= now,
+        is_past,
         created_at: event.created_at.format("%b %d, %Y %H:%M").to_string(),
         updated_at: event.updated_at.format("%b %d, %Y %H:%M").to_string(),
         is_series: event.series_id.is_some(),

--- a/src/web/portal/events.rs
+++ b/src/web/portal/events.rs
@@ -81,7 +81,7 @@ pub async fn events_list_api(
     html.push_str(r#"<div class="space-y-4">"#);
 
     for event in filtered_events {
-        let is_past = event.start_utc() < now;
+        let is_past = event.start_utc() <= now;
         // Label the wall-clock with the event's zone so a remote member
         // knows which local time it is (server-rendered — no browser
         // conversion like the public JSON/iCal path gets).

--- a/src/web/portal/events.rs
+++ b/src/web/portal/events.rs
@@ -81,7 +81,7 @@ pub async fn events_list_api(
     html.push_str(r#"<div class="space-y-4">"#);
 
     for event in filtered_events {
-        let is_past = event.start_time < now;
+        let is_past = event.start_utc() < now;
         // Label the wall-clock with the event's zone so a remote member
         // knows which local time it is (server-rendered — no browser
         // conversion like the public JSON/iCal path gets).


### PR DESCRIPTION
This PR ships agent-branch commits from multiple sources. Sections below enumerate each category present in the diff.

## Other commits

- fix: event-status-compares-wall-clock-to-utc-now (issues lane)



## Code Review: event-status-compares-wall-clock-to-utc-now

VERDICT: Approve

Clean, minimal, correct fix. All six wall-clock-vs-now comparisons now use `start_utc()` to compare derived instants. No display lines altered, sort untouched, regression test pins the bug. No security concerns. One pre-existing `<` vs `<=` inconsistency in `events.rs:84` vs admin sites is not introduced by this change.

## Concerns

- **Pre-existing `<` vs `<=` inconsistency for is_past** (src/web/portal/events.rs:84)
  `events.rs:84` uses `event.start_utc() < now` (strict less-than) while all admin sites use `<= now`. At the exact second of event start, the member list says 'not past' but admin says 'past'. Pre-existing — not introduced by this change — and a negligible edge case.

*Reviewer: openai_compatible/openrouter/qwen/qwen3.7-max*