### PR TITLE
agent-q changes: 1 commit(s) across other

### DIFF
--- a/issues/archive/2026-07-17-events-show-past-checkbox-bool-parse/issue.md
+++ b/issues/archive/2026-07-17-events-show-past-checkbox-bool-parse/issue.md
@@ -1,0 +1,13 @@
+## Report (issues lane candidate, a010)
+
+Origin: PUBLIC report (untrusted). The reporter's raw body is carried as quarantined DATA in `report-body.md`; the task below is the maintainer-approved diagnosis, NOT the reporter's text.
+
+Source: reported issue #109 — Selecting "Show Past events" on the Events page returns an error message
+
+## Diagnosis (maintainer-approved classification)
+
+The "Show past events" checkbox submits show_past=on, but the /portal/api/events/list handler types EventsListQuery.show_past as Option<bool>, which serde_urlencoded can't parse from "on"; the Query extractor 400s, breaking the spec-required events fragment (member-content) whenever the box is checked. Actually displaying past events is a separate behavior change and out of scope.
+
+## Acceptance
+
+The code must conform to the EXISTING specification in `openspec/specs/`. This is a bug fix; it carries NO spec delta. If the fix would require a behavior change, kick it back to the changes lane.

--- a/issues/archive/2026-07-17-events-show-past-checkbox-bool-parse/report-body.md
+++ b/issues/archive/2026-07-17-events-show-past-checkbox-bool-parse/report-body.md
@@ -1,0 +1,15 @@
+Symptom:
+Selecting "Show Past events" on the Events page returns a generic error message on the top-right corner of the screen. There was 1 formal event yesterday that occurred on 7/16/26 "Monthly HTB and Training Night 2026" on the new Coterie website which should no-longer be causing this error to occur "that event is not visible on this page or viewable in past events under the Social filter view".
+
+Steps to reproduce:
+1. Login to Neon Temple Coterie.
+
+2. Navigate to the Events page.
+
+3. On the top of the page, click the "Show past events" bubble. A generic error message "An error occurred. Please try again" should be displayed at the top-right corner of the screen for each instance the bubble is selected. The message(s) will disappear from view after a few moments afterwards.
+
+Reference:
+https://coterie.theneontemple.com/portal/events
+
+Version tested:
+Coterie v1.0.9 (latest release as-of 7/17/26).

--- a/issues/archive/2026-07-17-events-show-past-checkbox-bool-parse/tasks.md
+++ b/issues/archive/2026-07-17-events-show-past-checkbox-bool-parse/tasks.md
@@ -1,0 +1,2 @@
+- [x] 1.1 In src/web/portal/events.rs, change EventsListQuery.show_past from Option<bool> to Option<String> so the checkbox's "on"/absent serialization parses without a 400 (mirrors the archived announcements fix); derive the flag with .is_some() so the field is still read (no "never read" warning). Do NOT add past-event listing — the repository has no list_past and that would be a separate behavior change.
+- [x] 1.2 Add a regression test that GETs /portal/api/events/list?show_past=on and asserts a 200 with the list fragment (no test currently covers this endpoint).

--- a/src/web/portal/events.rs
+++ b/src/web/portal/events.rs
@@ -39,7 +39,9 @@ pub async fn events_page(
 #[derive(Debug, Deserialize)]
 pub struct EventsListQuery {
     pub event_type: Option<String>,
-    pub show_past: Option<bool>,
+    // HTML checkbox serializes as `show_past=on` when checked, absent when not — a
+    // bare String parses both; `Option<bool>` 400s on "on" (serde_urlencoded).
+    pub show_past: Option<String>,
 }
 
 pub async fn events_list_api(
@@ -48,6 +50,11 @@ pub async fn events_list_api(
     Query(query): Query<EventsListQuery>,
 ) -> impl IntoResponse {
     let member_id = current_user.member.id;
+
+    // The "Show past events" checkbox is accepted but not yet actioned: the
+    // repository has no past-event listing, so we only read presence to keep the
+    // field live. Adding past listing is a separate behavior change.
+    let _show_past = query.show_past.is_some();
 
     // Get upcoming events (past events not currently supported)
     let events = event_repo.list_upcoming(50).await.unwrap_or_default();
@@ -292,6 +299,110 @@ pub async fn cancel_rsvp_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        routing::get,
+        Router,
+    };
+    use chrono::Utc;
+    use tower::ServiceExt;
+
+    use crate::{
+        domain::{CreateMemberRequest, Event, EventType, EventVisibility, Member},
+        repository::{MemberRepository, SqliteEventRepository, SqliteMemberRepository},
+    };
+
+    async fn migrated_pool() -> sqlx::SqlitePool {
+        let pool = sqlx::sqlite::SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect("sqlite::memory:")
+            .await
+            .unwrap();
+        sqlx::migrate!("./migrations").run(&pool).await.unwrap();
+        pool
+    }
+
+    // Regression: the "Show past events" checkbox serializes as `show_past=on`.
+    // When `EventsListQuery.show_past` was `Option<bool>`, serde_urlencoded
+    // could not parse "on", so the `Query` extractor 400'd and the
+    // member-content events fragment (`GET /portal/api/events/list`) broke
+    // whenever the box was checked. It must now return 200 and render the list.
+    #[tokio::test]
+    async fn show_past_on_returns_list_fragment() {
+        let pool = migrated_pool().await;
+
+        let member_repo: Arc<dyn MemberRepository> =
+            Arc::new(SqliteMemberRepository::new(pool.clone()));
+        let member: Member = member_repo
+            .create(CreateMemberRequest {
+                email: "member@example.com".to_string(),
+                username: "member".to_string(),
+                full_name: "Member".to_string(),
+                password: "p4ssword_long_enough".to_string(),
+                membership_type_id: None,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        let event_repo: Arc<dyn EventRepository> =
+            Arc::new(SqliteEventRepository::new(pool.clone()));
+        let now = Utc::now();
+        event_repo
+            .create(Event {
+                id: Uuid::new_v4(),
+                title: "Upcoming Meetup".to_string(),
+                description: "Body".to_string(),
+                event_type: EventType::Social,
+                event_type_id: None,
+                visibility: EventVisibility::Public,
+                start_time: now + chrono::Duration::days(7),
+                end_time: None,
+                timezone: "UTC".to_string(),
+                location: None,
+                max_attendees: None,
+                rsvp_required: false,
+                image_url: None,
+                created_by: member.id,
+                created_at: now,
+                updated_at: now,
+                series_id: None,
+                occurrence_index: None,
+            })
+            .await
+            .unwrap();
+
+        let app = Router::new()
+            .route("/portal/api/events/list", get(events_list_api))
+            .layer(Extension(CurrentUser { member }))
+            .with_state(event_repo);
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/portal/api/events/list?show_past=on")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            resp.status(),
+            StatusCode::OK,
+            "checkbox `show_past=on` must parse, not 400"
+        );
+
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let body = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            body.contains("Upcoming Meetup"),
+            "list fragment should render the upcoming event, got: {body}"
+        );
+    }
 
     // Regression for #101: every RSVP fragment must be rooted in the same
     // `div.text-right` element the buttons target with


### PR DESCRIPTION
This PR ships agent-branch commits from multiple sources. Sections below enumerate each category present in the diff.

## Other commits

- fix: events-show-past-checkbox-bool-parse (issues lane)



## Code Review: events-show-past-checkbox-bool-parse

VERDICT: Approve

Clean, minimal bug fix: EventsListQuery.show_past changed from Option<bool> to Option<String> so the checkbox's `show_past=on` parses (Option<bool> 400s under serde_urlencoded), with a `let _show_past = query.show_past.is_some()` binding keeping the field read. The added regression test mirrors the archived announcements test verbatim (same migrated_pool, CurrentUser { member }, oneshot pattern) and asserts a 200 + fragment render for `?show_past=on`. No security issues, no injection surface (read-only GET, no string interpolation into SQL/markup beyond existing escaped paths), error handling unchanged, naming/idoms match the surrounding file. Comments document the why (checkbox serialization quirk, no past-listing yet) without restating the code. Approve.

*Reviewer: openai_compatible/openrouter/z-ai/glm-5.2*